### PR TITLE
Use array of concrete type in function a_star

### DIFF
--- a/src/shortestpaths/astar.jl
+++ b/src/shortestpaths/astar.jl
@@ -86,7 +86,7 @@ function a_star(g::AbstractGraph{U},  # the g
     f_score = fill(Inf, nv(g))
     f_score[s] = heuristic(s)
 
-    came_from = -ones(Integer, nv(g))
+    came_from = fill(-one(s), nv(g))
     came_from[s] = s
 
     a_star_impl!(g, t, open_set, closed_set, g_score, f_score, came_from, distmx, heuristic)


### PR DESCRIPTION
Previously the Array was of type `Integer`. Tests show `a_star` is
much faster after this commit.

EDIT: it would be better if `ones(Integer, n)` threw an error, rather than arbitrarily choosing to fill with `Int`s. But, that ship has sailed.