### PR TITLE
Fix bug in `adjacency_matrix(::SimpleGraph)` for Julia 1.7

### DIFF
--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -55,6 +55,9 @@ function _adjacency_matrix(g::AbstractGraph, T::DataType, neighborfn::Function, 
     for j in 1:n_v  # this is by column, not by row.
         if has_edge(g, j, j)
             push!(selfloops, j)
+            if !(T <: Bool) && !is_directed(g)
+                nz -= 1
+            end
         end
         dsts = sort(neighborfn(g, j)) # TODO for most graphs it might not be necessary to sort
         colpt[j + 1] = colpt[j] + length(dsts)


### PR DESCRIPTION
This fixes a bug in `adjacency_matrix(::SimpleGraph)` for Julia 1.7.

This PR is moved from https://github.com/sbromberger/LightGraphs.jl/pull/1595 and fixes the issue described in https://github.com/sbromberger/LightGraphs.jl/issues/1594.

As described in https://github.com/sbromberger/LightGraphs.jl/issues/1594, Julia 1.7 adds a stricter check on the `SparseMatrixCSC` constructor for consistency about the number of nonzero elements input. The number of nonzero elements are currently being overcounted in the case of `SimpleGraph` with self-loops, this should fix that overcounting.

Here is a minimal example:
```julia
julia> versioninfo()
Julia Version 1.7.0-rc1
Commit 9eade6195e (2021-09-12 06:45 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin19.6.0)
  CPU: Intel(R) Core(TM) m3-7Y32 CPU @ 1.10GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, skylake)

(@v1.7) pkg> st Graphs
      Status `~/.julia/environments/v1.7/Project.toml`
  [86223c79] Graphs v1.4.1 `~/.julia/dev/Graphs`

julia> using Graphs

julia> g = Graph(Edge.([1 => 2, 2 => 3]))
{3, 2} undirected simple Int64 graph

julia> adjacency_matrix(g)
3×3 SparseArrays.SparseMatrixCSC{Int64, Int64} with 4 stored entries:
 ⋅  1  ⋅
 1  ⋅  1
 ⋅  1  ⋅

julia> add_edge!(g, 1 => 1)
true

julia> adjacency_matrix(g)
3×3 SparseArrays.SparseMatrixCSC{Int64, Int64} with 5 stored entries:
 2  1  ⋅
 1  ⋅  1
 ⋅  1  ⋅
```
Without this fix I get:
```julia
(@v1.7) pkg> st Graphs
      Status `~/.julia/environments/v1.7/Project.toml`
  [86223c79] Graphs v1.4.1

julia> using Graphs

julia> g = Graph(Edge.([1 => 2, 2 => 3]))
{3, 2} undirected simple Int64 graph

julia> adjacency_matrix(g)
3×3 SparseArrays.SparseMatrixCSC{Int64, Int64} with 4 stored entries:
 ⋅  1  ⋅
 1  ⋅  1
 ⋅  1  ⋅

julia> add_edge!(g, 1 => 1)
true

julia> adjacency_matrix(g)
ERROR: ArgumentError: Illegal buffers for SparseMatrixCSC construction 3 [1, 3, 5, 6] [1, 2, 1, 3, 2] [1, 1, 1, 1, 1, 1]
Stacktrace:
 [1] SparseMatrixCSC
   @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.7/SparseArrays/src/sparsematrix.jl:29 [inlined]
 [2] SparseArrays.SparseMatrixCSC(m::Int64, n::Int64, colptr::Vector{Int64}, rowval::Vector{Int64}, nzval::Vector{Int64})
   @ SparseArrays /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.7/SparseArrays/src/sparsematrix.jl:44
 [3] _adjacency_matrix(g::SimpleGraph{Int64}, T::DataType, neighborfn::typeof(inneighbors), nzmult::Int64)
   @ Graphs.LinAlg ~/.julia/packages/Graphs/Mih78/src/linalg/spectral.jl:63
 [4] #adjacency_matrix#2
   @ ~/.julia/dev/Graphs/src/linalg/spectral.jl:25 [inlined]
 [5] adjacency_matrix (repeats 2 times)
   @ ~/.julia/dev/Graphs/src/linalg/spectral.jl:20 [inlined]
 [6] top-level scope
   @ REPL[24]:1
```