### PR TITLE
[Port] fix induced_subgraph indexing with vector of Bools

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -659,6 +659,10 @@ function induced_subgraph(g::T, vlist::AbstractVector{U}) where T <: AbstractGra
     return h, vmap
 end
 
+function induced_subgraph(g::AbstractGraph, vlist::AbstractVector{Bool})
+    length(vlist) == length(g) || throw(BoundsError(g, vlist))
+    return induced_subgraph(g, findall(vlist))
+end
 
 function induced_subgraph(g::AG, elist::AbstractVector{U}) where AG <: AbstractGraph{T} where T where U <: AbstractEdge
     h = zero(g)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -273,6 +273,14 @@
         @test h2 == h
         @test vm == collect(r)
         @test h2 == g[r]
+
+        r2 = falses(length(g))
+        r2[r] .= true
+        h2, vm = @inferred(induced_subgraph(g, r2))
+        @test h2 == h
+        @test vm == findall(r2)
+        @test h2 == g[r2]
+
     end
 
     g10 = complete_graph(10)
@@ -282,6 +290,12 @@
         @test ne(sg) == 6
 
         sg2, vm = @inferred(induced_subgraph(g, [5, 6, 7, 8]))
+        @test sg2 == sg
+        @test vm[4] == 8
+
+        bv = falses(length(g))
+        bv[5:8] .= true
+        sg2, vm = @inferred(induced_subgraph(g, bv))
         @test sg2 == sg
         @test vm[4] == 8
 


### PR DESCRIPTION
This is a port of [#1573](https://github.com/sbromberger/LightGraphs.jl/pull/1573)