### PR TITLE
Documentation fixes

### DIFF
--- a/docs/src/integration.md
+++ b/docs/src/integration.md
@@ -1,17 +1,7 @@
 # Integration with other packages
 
-*Graphs.jl*'s integration with other Julia packages is designed to be straightforward. Here are a few examples.
+*Graphs.jl*'s integration with other Julia packages is designed to be straightforward. Here are some examples.
 
-## [Graphs.jl](http://github.com/JuliaLang/Graphs.jl)
-
-Creating a Graphs.jl `simple_graph` is easy:
-
-```julia
-julia> s = simple_graph(nv(g), is_directed=Graphs.is_directed(g))
-julia> for e in Graphs.edges(g)
-           add_edge!(s,src(e), dst(e))
-       end
-```
 
 ## [Metis.jl](https://github.com/JuliaSparse/Metis.jl)
 

--- a/docs/src/matching.md
+++ b/docs/src/matching.md
@@ -1,3 +1,3 @@
 # Matching
 
-Maximum weight matching is supported in the companion package [LightGraphsMatching.jl](https://github.com/JuliaGraphs/LightGraphsMatching.jl).
+Maximum weight matching is supported in the companion package [GraphsMatching.jl](https://github.com/JuliaGraphs/GraphsMatching.jl).


### PR DESCRIPTION
In documentation, change link for [LightGraphsMatching.jl](https://github.com/JuliaGraphs/LightGraphsMatching.jl) to [GraphsMatching.jl](https://github.com/JuliaGraphs/GraphsMatching.jl), and remove redundant integration notes