### PR TITLE
Add incremental cycle detection algorithm

### DIFF
--- a/src/Experimental/Traversals/Traversals.jl
+++ b/src/Experimental/Traversals/Traversals.jl
@@ -5,6 +5,7 @@ module Traversals
 # to create new graph algorithms that rely on breadth-first or depth-first search traversals.
 
 using Graphs
+import ..Graphs: topological_sort
 using SimpleTraits
 """
     abstract type TraversalAlgorithm
@@ -141,7 +142,7 @@ mutable struct ParentState{T<:Integer} <: AbstractTraversalState
     parents::Vector{T}
 end
 
-@inline function newvisitfn!(s::ParentState, u, v) 
+@inline function newvisitfn!(s::ParentState, u, v)
     s.parents[v] = u
     return true
 end

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -83,6 +83,9 @@ simplecycles_hawick_james, maxsimplecycles, simplecycles, simplecycles_iter,
 simplecyclescount, simplecycleslength, karp_minimum_cycle_mean, cycle_basis,
 simplecycles_limited_length,
 
+# incremental cycles
+IncrementalCycleTracker, add_edge_checked!, topological_sort,
+
 # maximum_adjacency_visit
 mincut, maximum_adjacency_visit,
 
@@ -219,6 +222,7 @@ include("cycles/hawick-james.jl")
 include("cycles/karp.jl")
 include("cycles/basis.jl")
 include("cycles/limited_length.jl")
+include("cycles/incremental.jl")
 include("traversals/bfs.jl")
 include("traversals/bipartition.jl")
 include("traversals/greedy_color.jl")

--- a/src/cycles/incremental.jl
+++ b/src/cycles/incremental.jl
@@ -1,0 +1,266 @@
+using Base.Iterators: repeated
+
+# Abstract Interface
+
+"""
+    abstract type IncrementalCycleTracker
+
+The supertype for incremental cycle detection problems. The abstract type
+constructor IncrementalCycleTracker(G) may be used to automatically select
+a specific incremental cycle detection algorithm. See [`add_edge_checked!`](dfsdfsdfsdfref)
+for a usage example.
+"""
+abstract type IncrementalCycleTracker{I} <: AbstractGraph{I} end
+
+function (::Type{IncrementalCycleTracker})(s::AbstractGraph{I}; dir::Symbol=nothing) where {I}
+    # TODO: Once we have more algorithms, the poly-algorithm decision goes here.
+    # For now, we only have Algorithm N.
+    return DenseGraphICT_BFGT_N{something(dir, :out)}(s)
+end
+
+# Cycle Detection Interface
+"""
+    add_edge_checked!([f!,], ict::IncrementalCycleTracker, v, w)
+
+Using the incremental cycle tracker, ict, check whether adding the edge `v=>w`.
+Would introduce a cycle in the underlying graph. If so, return false and leave
+the ict intact. If not, update the underlying graph and return true.
+
+# Optional `f!` Argument
+
+By default the `add_edge!` function is used to update the underlying graph.
+However, for more complicated graphs, users may wish to manually specify the
+graph update operation. This may be accomplished by passing the optional `f!`
+callback arhgument. This callback is called on the underlying graph when no
+cycle is detected and is required to modify the underlying graph in order to
+effectuate the proposed edge addition.
+
+# Batched edge additions
+
+Optionally, either `v` or `w` (depending on the `in_out_reverse` flag) may be a
+collection of vertices representing a batched addition of vertices sharing a
+common source or target more efficiently than individual updates.
+
+## Example
+
+```jldoctest
+julia> G = SimpleDiGraph(3)
+
+julia> ict = IncrementalCycleTracker(G)
+BFGT_N cycle tracker on {3, 0} directed simple Int64 graph
+
+julia> add_edge_checked!(ict, 1, 2)
+true
+
+julia> collect(edges(G))
+1-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
+ Edge 1 => 2
+
+julia> add_edge_checked!(ict, 2, 3)
+true
+
+julia> collect(edges(G))
+2-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
+ Edge 1 => 2
+ Edge 2 => 3
+
+julia> add_edge_checked!(ict, 3, 1) # Would add a cycle
+false
+
+julia> collect(edges(G))
+2-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
+Edge 1 => 2
+Edge 2 => 3
+```
+"""
+function add_edge_checked! end
+
+to_edges(v::Integer, w::Integer) = (v=>w,)
+to_edges(v::Integer, ws) = zip(repeated(v), ws)
+to_edges(vs, w::Integer) = zip(vs, repeated(w))
+
+add_edge_checked!(ict::IncrementalCycleTracker, vs, ws) = add_edge_checked!(ict, vs, ws) do g
+    foreach(((v, w),)->add_edge!(g, v, w), to_edges(vs, ws))
+end
+
+# Utilities
+"""
+    struct TransactionalVector
+
+A vector with one checkpoint that may be reverted to by calling `revert!`. The setpoint itself
+is set by calling `commit!`.
+"""
+struct TransactionalVector{T} <: AbstractVector{T}
+    v::Vector{T}
+    log::Vector{Pair{Int, T}}
+    TransactionalVector(v::Vector{T}) where {T} =
+        new{T}(v, Vector{Pair{Int, T}}())
+end
+
+function commit!(v::TransactionalVector)
+    empty!(v.log)
+    return nothing
+end
+
+function revert!(vec::TransactionalVector)
+    for (idx, val) in reverse(vec.log)
+        vec.v[idx] = val
+    end
+    return nothing
+end
+
+function Base.setindex!(vec::TransactionalVector, val, idx)
+    oldval = vec.v[idx]
+    vec.v[idx] = val
+    push!(vec.log, idx=>oldval)
+    return nothing
+end
+Base.getindex(vec::TransactionalVector, idx) = vec.v[idx]
+Base.size(vec::TransactionalVector) = size(vec.v)
+
+function weak_topological_levels(g::AbstractGraph{I}) where {I}
+    levels = fill(-1, nv(g))
+    # Fill topological levels via dynamic programming dfs
+    worklist = Vector{Int}()
+    all_verts_max_level = 0
+    for v in vertices(g)
+        push!(worklist, v)
+        while !isempty(worklist)
+            v = last(worklist)
+            levels[v] = -2
+            visited_all = true
+            maxlevel = -1
+            for n in outneighbors(g, v)
+                l = levels[n]
+                maxlevel = max(l, maxlevel)
+                l == -2 && error("Graph is not a DAG")
+                if l == -1
+                    visited_all = false
+                    push!(worklist, n)
+                end
+            end
+            visited_all || continue
+            pop!(worklist)
+            new_level = maxlevel + 1
+            levels[v] = new_level
+            all_verts_max_level = max(all_verts_max_level, new_level)
+        end
+    end
+    return all_verts_max_level .- levels
+end
+
+# Specific Algorithms
+
+const bibliography = """
+## References
+
+[BFGT15] Michael A. Bender, Jeremy T. Fineman, Seth Gilbert, and Robert E. Tarjan. 2015
+    A New Approach to Incremental Cycle Detection and Related Problems.
+    ACM Trans. Algorithms 12, 2, Article 14 (December 2015), 22 pages.
+    DOI: http://dx.doi.org/10.1145/2756553
+"""
+
+## Bender, Algorithm N
+
+"""
+    struct DenseGraphICT_BFGT_N
+
+Implements the "Naive" (Algorithm N) Bender-Fineman-Gilbert-Tarjan one-way line search incremental cycle detector
+for dense graphs from [BFGT15] (Section 3).
+
+$bibliography
+"""
+struct DenseGraphICT_BFGT_N{InOut, I, G<:AbstractGraph{I}} <: IncrementalCycleTracker{I}
+    graph::G
+    levels::TransactionalVector{Int}
+    function DenseGraphICT_BFGT_N{InOut}(g::G) where {InOut, I, G<:AbstractGraph{I}}
+        if ne(g) == 0
+            # Common case fast path, no edges, all level start at 0.
+            levels = fill(0, nv(g))
+        else
+            levels = weak_topological_levels(g)
+        end
+        new{InOut, I, G}(g, TransactionalVector(levels))
+    end
+end
+
+function Base.show(io::IO, ict::DenseGraphICT_BFGT_N)
+    print(io, "BFGT_N cycle tracker on ")
+    show(io, ict.graph)
+end
+
+function topological_sort(ict::DenseGraphICT_BFGT_N{InOut}) where {InOut}
+    # The ICT levels are a weak topological ordering, so a sort of the levels
+    # will give a topological sort of the vertices.
+    perm = sortperm(ict.levels)
+    (InOut === :in) && (perm = reverse(perm))
+    return perm
+end
+
+# Even when both `v` and `w` are integer, we know that `v` would come first, so
+# we prefer to check for `v` as the cycle vertex in this case.
+add_edge_checked!(f!, ict::DenseGraphICT_BFGT_N{:out}, v::Integer, ws) =
+    _check_cycle_add!(f!, ict, to_edges(v, ws), v)
+add_edge_checked!(f!, ict::DenseGraphICT_BFGT_N{:in}, vs, w::Integer) =
+    _check_cycle_add!(f!, ict, to_edges(vs, w), w)
+
+### [BFGT15] Algorithm N
+#
+# Implementation Notes
+#
+# This is Algorithm N from [BFGT15] (Section 3), plus limited patching support and
+# a number of standard tricks. Namely:
+#
+# 1. Batching is supported as long as there is only a single source or destination
+#    vertex. General batching is left as an open problem. The reason that the
+#    single source/dest batching is easy to add is that we know that either the
+#    source or the destination vertex is guaranteed to be a part of any cycle
+#    that we may have added. Thus we're guaranteed to encounter one of the two
+#    verticies in our cycle validation and the rest of the algorithm goes through
+#    as usual.
+# 2. We opportunistically traverse each edge when we see it and only add it
+#    to the worklist if we know that traversal will recurse further.
+# 3. We add some early out checks to detect we're about to do redundant work.
+function _check_cycle_add!(f!, ict::DenseGraphICT_BFGT_N{InOut}, edges, v) where {InOut}
+    g = ict.graph
+    worklist = Pair{Int, Int}[]
+    # TODO: In the case where there's a single target vertex, we could saturate
+    # the level first before we assign it to the tracked vector to save some
+    # log space.
+    for (v, w) in edges
+        (InOut === :in) && ((v, w) = (w, v))
+        if ict.levels[v] < ict.levels[w]
+            continue
+        end
+        v == w && return false
+        ict.levels[w] = ict.levels[v] + 1
+        push!(worklist, v=>w)
+    end
+    while !isempty(worklist)
+        (x, y) = popfirst!(worklist)
+        xlevel = ict.levels[x]
+        ylevel = ict.levels[y]
+        if xlevel >= ylevel
+            # The xlevel may have been incremented further since we added this
+            # edge to the worklist.
+            ict.levels[y] = ylevel = xlevel + 1
+        elseif ylevel > xlevel + 1
+            # Some edge traversal scheduled for later already incremented this
+            # level past where we would have been. Delay processing until then.
+            continue
+        end
+        for z in (InOut === :in ? inneighbors(g, y) : outneighbors(g, y))
+            if z == v
+                revert!(ict.levels)
+                return false
+            end
+            if ylevel >= ict.levels[z]
+                ict.levels[z] = ylevel + 1
+                push!(worklist, y=>z)
+            end
+        end
+    end
+    commit!(ict.levels)
+    f!(g)
+    return true
+end

--- a/test/cycles/incremental.jl
+++ b/test/cycles/incremental.jl
@@ -1,0 +1,38 @@
+@testset "ICT" begin
+    Gempty = SimpleDiGraph(3)
+    Gsomedges = SimpleDiGraph(6)
+    add_edge!(Gsomedges, 4, 5)
+    add_edge!(Gsomedges, 6, 5)
+    for Gtemplate in (Gempty, Gsomedges)
+        for dir in (:out, :in)
+            G = copy(Gtemplate)
+            ict = IncrementalCycleTracker(G; dir)
+            @test_nowarn repr(ict)
+            @test add_edge_checked!(ict, 1, 2)
+            @test add_edge_checked!(ict, 2, 3)
+            @test length(edges(G)) == 2 + length(edges(Gtemplate))
+            @test !add_edge_checked!(ict, 3, 1)
+            @test !add_edge_checked!(ict, 3, 2)
+            if dir === :in
+                @test !add_edge_checked!(ict, (2, 3), 1)
+                @test !add_edge_checked!(ict, (1, 3), 2)
+            else
+                @test !add_edge_checked!(ict, 3, (1,2))
+                @test !add_edge_checked!(ict, 2, (1,3))
+            end
+            @test length(edges(G)) == 2 + length(edges(Gtemplate))
+            @test filter(in((1,2,3)), topological_sort(ict)) == [1, 2, 3]
+        end
+    end
+
+    Gcycle2 = SimpleDiGraph(2)
+    add_edge!(Gcycle2, 1, 2)
+    add_edge!(Gcycle2, 2, 1)
+    @test_throws ErrorException IncrementalCycleTracker(Gcycle2)
+
+    Gcycle3 = SimpleDiGraph(3)
+    add_edge!(Gcycle3, 1, 2)
+    add_edge!(Gcycle3, 2, 3)
+    add_edge!(Gcycle3, 3, 1)
+    @test_throws ErrorException IncrementalCycleTracker(Gcycle3)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,13 +11,13 @@ using Statistics: mean
 
 const testdir = dirname(@__FILE__)
 
-testgraphs(g) = is_directed(g) ? [g, DiGraph{UInt8}(g), DiGraph{Int16}(g)] : [g, Graph{UInt8}(g), Graph{Int16}(g)] 
+testgraphs(g) = is_directed(g) ? [g, DiGraph{UInt8}(g), DiGraph{Int16}(g)] : [g, Graph{UInt8}(g), Graph{Int16}(g)]
 testgraphs(gs...) = vcat((testgraphs(g) for g in gs)...)
 testdigraphs = testgraphs
 
 # some operations will create a large graph from two smaller graphs. We
 # might error out on very small eltypes.
-testlargegraphs(g) = is_directed(g) ? [g, DiGraph{UInt16}(g), DiGraph{Int32}(g)] : [g, Graph{UInt16}(g), Graph{Int32}(g)] 
+testlargegraphs(g) = is_directed(g) ? [g, DiGraph{UInt16}(g), DiGraph{Int32}(g)] : [g, Graph{UInt16}(g), Graph{Int32}(g)]
 testlargegraphs(gs...) = vcat((testlargegraphs(g) for g in gs)...)
 
 tests = [
@@ -35,6 +35,7 @@ tests = [
     "cycles/karp",
     "cycles/basis",
     "cycles/limited_length",
+    "cycles/incremental",
     "edit_distance",
     "connectivity",
     "persistence/persistence",


### PR DESCRIPTION
This adds the abstract interface for and a basic, naive implementation
of an algorithm to solve the incremental (online) cycle detection problem.
The incremental cycle detection problem is as follows:

Starting from some initial acyclic (directed) graph (here taken to be empty),
process a series of edge additions, stopping after the first edge
addition that introduces a cycle.

The algorithms for this problem have been developed and improved mostly
over the past five years or so, so they are not currently widely used
(or available in other libraries). That said, ModelingToolkit was using
an implementation in its DAE tearing code (which I intend to replace
with a version based on this code) and there are recent papers showing
applications in compiler optimizations.

The main focus of the current PR is the abstract interface. The algorithm
itself is Algorithm N (for "Naive") from [BFGT15] Section 3. The reference
develops several more algorithms with differing performance patterns,
depending on the sparsity of the graph and there are further improvements
to the asymptotics in the subsequent literature. However, Algorithm N is
simple to understand and extend and works ok for what is needed in MTK,
so I am not currently planning to implement the more advanced algorithms.
I do want to make sure the extension point exists to add them in the future,
which I believe this approach accomplishes.

[BFGT15] Michael A. Bender, Jeremy T. Fineman, Seth Gilbert, and Robert E. Tarjan. 2015
    A New Approach to Incremental Cycle Detection and Related Problems.
    ACM Trans. Algorithms 12, 2, Article 14 (December 2015), 22 pages.
    DOI: http://dx.doi.org/10.1145/2756553