### PR TITLE
Update codecov patch to 90%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     patch:
       default:
-        target: '97'
+        target: '90'
     project:
       default:
         target: '90'


### PR DESCRIPTION
Just to get more greens on PRs. 97% almost always gives us PRs failing because of codecov patch.