### PR TITLE
Move Project status lower in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ LightGraphs and Graphs are functionally identical, still there are some steps in
 * Increment your version number. Following semantic versioning, we suggest a patch release when no graphs or other `Graphs.jl`-objects can be passed through the API of your package by those depending on it, otherwise consider it a breaking release. "Passed through" entails created outside and consumed inside your package and vice versa.
 * Tag a release.
 
-
-
 # Citing
 
 We encourage you to cite our work if you have used our libraries, tools or datasets, refer to `CITATION.bib`.

--- a/README.md
+++ b/README.md
@@ -4,29 +4,6 @@
 [![codecov.io](http://codecov.io/github/JuliaGraphs/Graphs.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaGraphs/Graphs.jl?branch=master)
 [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliagraphs.org/Graphs.jl/dev/)
 
-## Current Project Status
-
-The Graphs project is a reboot of the now-archived LightGraphs
-package, which remains available on GitHub at
-[sbromberger/LightGraphs.jl](https://github.com/sbromberger/LightGraphs.jl). If
-you don't need any new features developed since the fork, you can continue to
-use older versions of LightGraphs indefinitely. New versions will be released
-here using the name Graphs instead of LightGraphs. There was an older package
-also called Graphs. The source history and versions are still available in
-this repository, but the current code base is unrelated to the old Graphs code
-and is derived purely from LightGraphs. To access the history of the old Graphs code,
-you can start from [commit 9a25019](https://github.com/JuliaGraphs/Graphs.jl/commit/9a2501948053f60c630caf9d4fb257e689629041).
-
-**Transition from LightGraphs to Graphs:**
-
-LightGraphs and Graphs are functionally identical, still there are some steps involved making the change:
-
-* Change `LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"` to `Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"` in your Project.toml. 
-* Update your `using` and `import` statements.
-* Update your type constraints and other references to `LightGraphs` to `Graphs`.
-* Increment your version number. Following semantic versioning, we suggest a patch release when no graphs or other `Graphs.jl`-objects can be passed through the API of your package by those depending on it, otherwise consider it a breaking release. "Passed through" entails created outside and consumed inside your package and vice versa.
-* Tag a release.
-
 ## Overview 
 
 Graphs offers both (a) a set of simple, concrete graph implementations -- `Graph`
@@ -76,6 +53,31 @@ We welcome contributions and bug reports! Please see [CONTRIBUTING.md](https://g
 for guidance on development and bug reporting.
 
 JuliaGraphs development subscribes to the [Julia Community Standards](https://julialang.org/community/standards/).
+
+## Project Status
+
+The Graphs project is a reboot of the LightGraphs
+package (archived in October 2021), which remains available on GitHub at
+[sbromberger/LightGraphs.jl](https://github.com/sbromberger/LightGraphs.jl). If
+you don't need any new features developed since the fork, you can continue to
+use older versions of LightGraphs indefinitely. New versions will be released
+here using the name Graphs instead of LightGraphs. There was an older package
+also called Graphs. The source history and versions are still available in
+this repository, but the current code base is unrelated to the old Graphs code
+and is derived purely from LightGraphs. To access the history of the old Graphs code,
+you can start from [commit 9a25019](https://github.com/JuliaGraphs/Graphs.jl/commit/9a2501948053f60c630caf9d4fb257e689629041).
+
+**Transition from LightGraphs to Graphs:**
+
+LightGraphs and Graphs are functionally identical, still there are some steps involved making the change:
+
+* Change `LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"` to `Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"` in your Project.toml. 
+* Update your `using` and `import` statements.
+* Update your type constraints and other references to `LightGraphs` to `Graphs`.
+* Increment your version number. Following semantic versioning, we suggest a patch release when no graphs or other `Graphs.jl`-objects can be passed through the API of your package by those depending on it, otherwise consider it a breaking release. "Passed through" entails created outside and consumed inside your package and vice versa.
+* Tag a release.
+
+
 
 # Citing
 


### PR DESCRIPTION
@jpfairbanks @simonschoelly Is this ok? I thought it is best to have focus on the package capabilities, and move the transition stuff towards the end.