### PR TITLE
adjacency_matrix: Collect neighbors before sorting them

### DIFF
--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -59,7 +59,7 @@ function _adjacency_matrix(g::AbstractGraph, T::DataType, neighborfn::Function, 
                 nz -= 1
             end
         end
-        dsts = sort(collect(neighborfn(g, j))) # TODO for most graphs it might not be necessary to sort
+        dsts = sort!(collect(neighborfn(g, j))) # TODO for most graphs it might not be necessary to sort
         colpt[j + 1] = colpt[j] + length(dsts)
         append!(rowval, dsts)
     end

--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -59,7 +59,7 @@ function _adjacency_matrix(g::AbstractGraph, T::DataType, neighborfn::Function, 
                 nz -= 1
             end
         end
-        dsts = sort(neighborfn(g, j)) # TODO for most graphs it might not be necessary to sort
+        dsts = sort(collect(neighborfn(g, j))) # TODO for most graphs it might not be necessary to sort
         colpt[j + 1] = colpt[j] + length(dsts)
         append!(rowval, dsts)
     end


### PR DESCRIPTION
The neighbors list may be an iterator that is not sortable. Make
sure to collect it first to get an array back.