### PR TITLE
Make zero function not mandatory for AbstractGraph interface

### DIFF
--- a/docs/src/developing.md
+++ b/docs/src/developing.md
@@ -20,7 +20,6 @@ within the Graphs package should just work:
   should be implemented with **both** of the following signatures:
   - `is_directed(::Type{CustomGraph})::Bool` (example: `is_directed(::Type{<:CustomGraph}) = false`)
   - `is_directed(g::CustomGraph)::Bool`
-- [`zero`](@ref)
 
 If the graph structure is designed to represent weights on edges, the [`weights`](@ref) function should also be defined.
 Note that the output does not necessarily have to be a dense matrix, but it must be a subtype of `AbstractMatrix{<:Real}` and indexable via `[u, v]`.


### PR DESCRIPTION
The current documentation declares the `zero` function as mandatory for any implementation of `AbstractGraph`. This function takes a graph (type) and constructs a graph of the same type with zero vertices. I propose to remove that requirement. My reasons for that are

1. The existence of `zero` for any graph type assumes that it is possible to have such a graph without any vertices. But for some graph types it is not clear, that such a graph even exists, for example some wrapper types that take some existing object and return a graph view of that object, parametrized graphs such as hypercubes (such a hypercube would have dimension -infinity), or certain geometric graphs.
2. It makes it difficult to construct wrapper graphs, as a graph wrapping another object must also implement some functionality for constructing an object of the wrapped type.
3. Constructing a graph with zero vertices usually only makes sense if that graph is mutable and implements `add_vertex!` and `add_edge!`, but this is not required for all graph types.

Removing this requirement should therefore make it easier to create custom subtypes of `AbstractGraph`.