### PR TITLE
Add more Julia versions to ci/cd workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 'nightly'
           - '1'
+          - '1.3'
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         version:
           - 'nightly'
           - '1'
+          - '1.6'
           - '1.3'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "1.5.0"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Inflate = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
@@ -16,6 +17,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ArnoldiMethod = "0.1, 0.2"
+Compat = "3.40"
 DataStructures = "0.17, 0.18"
 Inflate = "0.1"
 SimpleTraits = "0.9"

--- a/src/Experimental/ShortestPaths/johnson.jl
+++ b/src/Experimental/ShortestPaths/johnson.jl
@@ -1,3 +1,7 @@
+
+# Currently used to support the ismutable function that is not available in Julia < v1.7
+using Compat
+
 """
     struct Johnson <: ShortestPathAlgorithm
 
@@ -26,7 +30,7 @@ function shortest_paths(g::AbstractGraph{U}, distmx::AbstractMatrix{T}, ::Johnso
     #Change when parallel implementation of Bellman Ford available
     wt_transform = Graphs.Experimental.ShortestPaths.dists(shortest_paths(g, vertices(g), distmx, BellmanFord()))
 
-    if !ismutable(distmx) && type_distmx !=  Graphs.DefaultDistance
+    @compat if !ismutable(distmx) && type_distmx !=  Graphs.DefaultDistance
         distmx = sparse(distmx) #Change reference, not value
     end
 
@@ -51,7 +55,7 @@ function shortest_paths(g::AbstractGraph{U}, distmx::AbstractMatrix{T}, ::Johnso
         dists[:, v] .+= wt_transform[v] #Vertical traversal prefered
     end
 
-    if ismutable(distmx)
+    @compat if ismutable(distmx)
         for e in edges(g)
             distmx[src(e), dst(e)] += wt_transform[dst(e)] - wt_transform[src(e)]
         end

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -6,6 +6,9 @@ using SimpleTraits
 using ArnoldiMethod
 using Statistics: mean
 
+# Currently used to support the ismutable function that is not available in Julia < v1.7
+using Compat
+
 using Inflate: InflateGzipStream
 using DataStructures: IntDisjointSets, PriorityQueue, dequeue!, dequeue_pair!, enqueue!, heappop!, heappush!, in_same_set, peek, union!, find_root!
 using LinearAlgebra: I, Symmetric, diagm, eigen, eigvals, norm, rmul!, tril, triu

--- a/src/Parallel/shortestpaths/johnson.jl
+++ b/src/Parallel/shortestpaths/johnson.jl
@@ -1,3 +1,7 @@
+
+# Currently used to support the ismutable function that is not available in Julia < v1.7
+using Compat
+
 function johnson_shortest_paths(g::AbstractGraph{U},
 distmx::AbstractMatrix{T}=weights(g)) where T <: Real where U <: Integer
 
@@ -6,7 +10,7 @@ distmx::AbstractMatrix{T}=weights(g)) where T <: Real where U <: Integer
 #Change when parallel implementation of Bellman Ford available
     wt_transform = bellman_ford_shortest_paths(g, vertices(g), distmx).dists
 
-    if !ismutable(distmx) && type_distmx !=  Graphs.DefaultDistance
+    @compat if !ismutable(distmx) && type_distmx !=  Graphs.DefaultDistance
         distmx = sparse(distmx) #Change reference, not value
     end
 
@@ -28,7 +32,7 @@ distmx::AbstractMatrix{T}=weights(g)) where T <: Real where U <: Integer
         dists[:, v] .+= wt_transform[v] #Vertical traversal prefered
     end
 
-    if ismutable(distmx)
+    @compat if ismutable(distmx)
         for e in edges(g)
             distmx[src(e), dst(e)] += wt_transform[dst(e)] - wt_transform[src(e)]
         end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -844,7 +844,7 @@ function merge_vertices!(g::Graph{T}, vs::Vector{U} where U <: Integer) where T
 
 
     # Drop excess vertices
-    g.fadjlist = g.fadjlist[begin:(end - length(vs)+1)]
+    g.fadjlist = g.fadjlist[firstindex(g.fadjlist):(end - length(vs)+1)]
 
     # Correct edge counts
     g.ne = sum(degree(g, i) for i in vertices(g)) / 2

--- a/src/shortestpaths/johnson.jl
+++ b/src/shortestpaths/johnson.jl
@@ -30,7 +30,7 @@ function johnson_shortest_paths(g::AbstractGraph{U},
     #Change when parallel implementation of Bellman Ford available
     wt_transform = bellman_ford_shortest_paths(g, vertices(g), distmx).dists
 
-    if !ismutable(distmx) && type_distmx !=  Graphs.DefaultDistance
+    @compat if !ismutable(distmx) && type_distmx !=  Graphs.DefaultDistance
         distmx = sparse(distmx) #Change reference, not value
     end
 
@@ -55,7 +55,7 @@ function johnson_shortest_paths(g::AbstractGraph{U},
         dists[:, v] .+= wt_transform[v] #Vertical traversal prefered
     end
 
-    if ismutable(distmx)
+    @compat if ismutable(distmx)
         for e in edges(g)
             distmx[src(e), dst(e)] += wt_transform[dst(e)] - wt_transform[src(e)]
         end


### PR DESCRIPTION
This workflow adds the nightly version of Julia and v1.3 to the test workflow. I am currently not exactly sure, which minimal Julia version we should support, but v1.3 is certainly a good start.

I also had to do some changes to ensure that this package still works on Julia v1.3.