### PR TITLE
Make minimum Julia version v1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           - 'nightly'
           - '1'
           - '1.6'
-          - '1.3'
         os:
           - ubuntu-latest
           - macos-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Graphs"
 uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-version = "1.5.1"
+version = "1.6.0"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
@@ -19,9 +19,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ArnoldiMethod = "0.1, 0.2"
 Compat = "3.40"
 DataStructures = "0.17, 0.18"
-Inflate = "0.1"
+Inflate = "0.1.2"
 SimpleTraits = "0.9"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Installation is straightforward: enter Pkg mode by hitting `]`, and then
 * There was also an older package also called Graphs (git tags `v0.2.5` through `v0.10.3`), but the current code base here is a fork of LightGraphs v1.3.5.
 * All older LightGraphs versions are tagged using the naming scheme `lg-vX.Y.Z` rather than plain `vX.Y.Z` which is used for old Graphs versions (≤ v0.10) and newer versions derived from LightGraphs but released with the Graphs name (≥ v1.4).
 * If you are using a version of Julia prior to 1.x, then you should use LightGraphs.jl at `lg-v.12.*` or Graphs.jl at `v0.10.3`
+* If you are using a version of Julia prior to 1.6, then you should use Graphs.jl at `v1.5.1`
 * Later versions: Some functionality might not work with prerelease / unstable / nightly versions of Julia. If you run into a problem, please file an issue.
 
 # Contributing and Reporting Bugs


### PR DESCRIPTION
This PR makes Julia v1.6 the minimum required version for Graphs.jl.

I also would bump the version of this package to v1.6, so that we could still back port fixes for older Julia versions into the Graphs.jl v1.5.x space, and because it is just nice that the version of Julia then aligns with the of Graphs.jl

If any downstream package has some issues with that, please raise your objections here, but in any case, it should still be possible for you to use Graphs.jl at version v1.5.1.