### PR TITLE
Make squash specialized on simple graphs

### DIFF
--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -13,14 +13,14 @@ import Graphs:
     src, dst, edgetype, nv, ne, vertices, edges, is_directed,
     has_vertex, has_edge, inneighbors, outneighbors, all_neighbors,
     deepcopy_adjlist, indegree, outdegree, degree, has_self_loops,
-    num_self_loops, insorted
+    num_self_loops, insorted, squash
 
 using Random: GLOBAL_RNG, AbstractRNG
 
 export AbstractSimpleGraph, AbstractSimpleEdge,
     SimpleEdge, SimpleGraph, SimpleGraphFromIterator, SimpleGraphEdge,
     SimpleDiGraph, SimpleDiGraphFromIterator, SimpleDiGraphEdge,
-    add_vertex!, add_edge!, rem_vertex!, rem_vertices!, rem_edge!,
+    add_vertex!, add_edge!, rem_vertex!, rem_vertices!, rem_edge!, squash,
     # randgraphs
     erdos_renyi, expected_degree_graph, watts_strogatz, random_regular_graph,
     random_regular_digraph, random_configuration_model, random_tournament_digraph,
@@ -214,6 +214,7 @@ include("./simpleedge.jl")
 include("./simpledigraph.jl")
 include("./simplegraph.jl")
 include("./simpleedgeiter.jl")
+include("./specializations.jl")
 include("./generators/deprecations.jl")
 include("./generators/staticgraphs.jl")
 include("./generators/randgraphs.jl")

--- a/src/SimpleGraphs/specializations.jl
+++ b/src/SimpleGraphs/specializations.jl
@@ -11,18 +11,18 @@ function Graphs.squash(g::Union{SimpleGraph, SimpleDiGraph}; alwayscopy::Bool=tr
     G = is_directed(g) ? SimpleDiGraph : SimpleGraph
     T = eltype(g)
 
-    (!alwayscopy && T <: Union{Int8, UInt8}) && return g
-    nv(g) < typemax(Int8)     && return G{Int8}(g)
-    nv(g) < typemax(UInt8)    && return G{UInt8}(g)
+    (!alwayscopy && T <: Union{Int8, UInt8})   && return g
+    nv(g) < typemax(Int8)                      && return G{Int8}(g)
+    nv(g) < typemax(UInt8)                     && return G{UInt8}(g)
     (!alwayscopy && T <: Union{Int16, UInt16}) && return g
-    nv(g) < typemax(Int16)    && return G{Int16}(g)
-    nv(g) < typemax(UInt16)   && return G{UInt16}(g)
+    nv(g) < typemax(Int16)                     && return G{Int16}(g)
+    nv(g) < typemax(UInt16)                    && return G{UInt16}(g)
     (!alwayscopy && T <: Union{Int32, UInt32}) && return g
-    nv(g) < typemax(Int32)    && return G{Int32}(g)
-    nv(g) < typemax(UInt32)   && return G{UInt32}(g)
+    nv(g) < typemax(Int32)                     && return G{Int32}(g)
+    nv(g) < typemax(UInt32)                    && return G{UInt32}(g)
     (!alwayscopy && T <: Union{Int64, UInt64}) && return g
-    nv(g) < typemax(Int64)    && return G{Int64}(g)
-    nv(g) < typemax(UInt64)   && return G{UInt64}(g)
+    nv(g) < typemax(Int64)                     && return G{Int64}(g)
+    nv(g) < typemax(UInt64)                    && return G{UInt64}(g)
 
     return alwayscopy ? copy(g) : g
 end

--- a/src/SimpleGraphs/specializations.jl
+++ b/src/SimpleGraphs/specializations.jl
@@ -1,0 +1,22 @@
+
+function Graphs.squash(g::Union{SimpleGraph, SimpleDiGraph})
+
+    G = is_directed(g) ? SimpleDiGraph : SimpleGraph
+    T = eltype(g)
+
+    T <: Union{Int8, UInt8}   && return g
+    nv(g) < typemax(Int8)     && return G{Int8}(g)
+    nv(g) < typemax(UInt8)    && return G{UInt8}(g)
+    T <: Union{Int16, UInt16} && return g
+    nv(g) < typemax(Int16)    && return G{Int16}(g)
+    nv(g) < typemax(UInt16)   && return G{UInt16}(g)
+    T <: Union{Int32, UInt32} && return g
+    nv(g) < typemax(Int32)    && return G{Int32}(g)
+    nv(g) < typemax(UInt32)   && return G{UInt32}(g)
+    T <: Union{Int64, UInt64} && return g
+    nv(g) < typemax(Int64)    && return G{Int64}(g)
+    nv(g) < typemax(UInt64)   && return G{UInt64}(g)
+
+    return g
+end
+

--- a/src/SimpleGraphs/specializations.jl
+++ b/src/SimpleGraphs/specializations.jl
@@ -1,6 +1,6 @@
 
 """
-    squash(g::Union{SimpleGraph. SimpleDiGraph}; alwayscopy=true)
+    squash(g::Union{SimpleGraph, SimpleDiGraph}; alwayscopy=true)
 
 Specialised version of `Graphs::Squash` for `SimpleGraph` and `SimpleDiGraph`.
 If `alwayscopy` is `true`, the resulting graph will always be a copy, otherwise

--- a/src/SimpleGraphs/specializations.jl
+++ b/src/SimpleGraphs/specializations.jl
@@ -2,7 +2,7 @@
 """
     squash(g::Union{SimpleGraph, SimpleDiGraph}; alwayscopy=true)
 
-Specialised version of `Graphs::Squash` for `SimpleGraph` and `SimpleDiGraph`.
+Specialised version of `Graphs.squash` for `SimpleGraph` and `SimpleDiGraph`.
 If `alwayscopy` is `true`, the resulting graph will always be a copy, otherwise
 it can also be the original graph.
 """

--- a/src/SimpleGraphs/specializations.jl
+++ b/src/SimpleGraphs/specializations.jl
@@ -1,22 +1,29 @@
 
-function Graphs.squash(g::Union{SimpleGraph, SimpleDiGraph})
+"""
+    squash(g::Union{SimpleGraph. SimpleDiGraph}; alwayscopy=true)
+
+Specialised version of `Graphs::Squash` for `SimpleGraph` and `SimpleDiGraph`.
+If `alwayscopy` is `true`, the resulting graph will always be a copy, otherwise
+it can also be the original graph.
+"""
+function Graphs.squash(g::Union{SimpleGraph, SimpleDiGraph}; alwayscopy::Bool=true)
 
     G = is_directed(g) ? SimpleDiGraph : SimpleGraph
     T = eltype(g)
 
-    T <: Union{Int8, UInt8}   && return g
+    (!alwayscopy && T <: Union{Int8, UInt8}) && return g
     nv(g) < typemax(Int8)     && return G{Int8}(g)
     nv(g) < typemax(UInt8)    && return G{UInt8}(g)
-    T <: Union{Int16, UInt16} && return g
+    (!alwayscopy && T <: Union{Int16, UInt16}) && return g
     nv(g) < typemax(Int16)    && return G{Int16}(g)
     nv(g) < typemax(UInt16)   && return G{UInt16}(g)
-    T <: Union{Int32, UInt32} && return g
+    (!alwayscopy && T <: Union{Int32, UInt32}) && return g
     nv(g) < typemax(Int32)    && return G{Int32}(g)
     nv(g) < typemax(UInt32)   && return G{UInt32}(g)
-    T <: Union{Int64, UInt64} && return g
+    (!alwayscopy && T <: Union{Int64, UInt64}) && return g
     nv(g) < typemax(Int64)    && return G{Int64}(g)
     nv(g) < typemax(UInt64)   && return G{UInt64}(g)
 
-    return g
+    return alwayscopy ? copy(g) : g
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -389,10 +389,22 @@ ne(g) / (nv(g) * (nv(g) - 1))
 """
     squash(g)
 
-Return a copy of a graph with the smallest practical type that
+Return a copy of a graph with the smallest practical eltype that
 can accommodate all vertices.
+
+May also return the original graph if the eltype does not change.
 """
 function squash(g::AbstractGraph)
+
+    # TODO this version check can be removed when we increase the required Julia version
+    deprecation_msg = "squash(::AbstractGraph) is deprecated in favor of methods that specialize on the graph type."
+    if VERSION >= v"1.5.2"
+        Base.depwarn(deprecation_msg, :squash; force=true)
+    else
+        Base.depwarn(deprecation_msg, :squash)
+    end
+
+
     gtype = is_directed(g) ? DiGraph : Graph
     validtypes = [UInt8, UInt16, UInt32, UInt64, Int64]
     nvg = nv(g)

--- a/test/core.jl
+++ b/test/core.jl
@@ -91,9 +91,4 @@
         end
 
     end
-    @testset "squash" begin
-        @testset "$g" for g in testgraphs(g5w, g5wd)
-            @test eltype(squash(g)) == UInt8
-        end
-    end 
 end

--- a/test/simplegraphs/runtests.jl
+++ b/test/simplegraphs/runtests.jl
@@ -84,6 +84,7 @@ const simple_tests = [
     "simplegraphs",
     "simpleedge",
     "simpleedgeiter",
+    "specializations",
     "generators/randgraphs",
     "generators/staticgraphs",
     "generators/smallgraphs",

--- a/test/simplegraphs/specializations.jl
+++ b/test/simplegraphs/specializations.jl
@@ -1,0 +1,24 @@
+
+@testset "squash" begin
+    @testset "$g_in" for (g_in, g_expected) in [
+                (SimpleGraph{Int64}(),       SimpleGraph{Int8}()),
+                (SimpleDiGraph{UInt8}(),     SimpleDiGraph{UInt8}()),
+                (path_graph(Int16(126)),     path_graph(Int8(126))),
+                (path_digraph(Int16(127)),   path_digraph(UInt8(127))),
+                (path_graph(Int16(254)),     path_graph(UInt8(254))),
+                (path_digraph(Int16(255)),   path_digraph(Int16(255))),
+                (path_graph(UInt16(255)),    path_graph(UInt16(255))),
+                (star_graph(Int16(32766)),   star_graph(Int16(32766))),
+                (star_digraph(Int32(32767)), star_digraph(UInt16(32767))),
+                (cycle_graph(Int128(123)),   cycle_graph(Int8(123))),
+               ]
+
+        g_actual = squash(g_in)
+        @test typeof(g_actual) === typeof(g_expected)
+        @test g_actual == g_expected
+        if typeof(g_in) === typeof(g_actual)
+            @test g_in === g_actual
+        end
+    end
+end
+

--- a/test/simplegraphs/specializations.jl
+++ b/test/simplegraphs/specializations.jl
@@ -1,22 +1,21 @@
 
 @testset "squash" begin
-    @testset "$g_in" for (g_in, g_expected) in [
+    @testset "$g_in, kwargs=$kwargs" for kwargs in [(), (alwayscopy=false,), (alwayscopy=true,)], (g_in, g_expected) in [
                 (SimpleGraph{Int64}(),       SimpleGraph{Int8}()),
-                (SimpleDiGraph{UInt8}(),     SimpleDiGraph{UInt8}()),
+                (SimpleDiGraph{UInt8}(),     kwargs == (alwayscopy=false,) ? SimpleDiGraph{UInt8}() : SimpleDiGraph{Int8}()) ,
                 (path_graph(Int16(126)),     path_graph(Int8(126))),
                 (path_digraph(Int16(127)),   path_digraph(UInt8(127))),
                 (path_graph(Int16(254)),     path_graph(UInt8(254))),
                 (path_digraph(Int16(255)),   path_digraph(Int16(255))),
-                (path_graph(UInt16(255)),    path_graph(UInt16(255))),
+                (path_graph(UInt16(255)),    kwargs == (alwayscopy=false,) ? path_graph(UInt16(255)) : path_graph(Int16(255))),
                 (star_graph(Int16(32766)),   star_graph(Int16(32766))),
                 (star_digraph(Int32(32767)), star_digraph(UInt16(32767))),
                 (cycle_graph(Int128(123)),   cycle_graph(Int8(123))),
                ]
-
-        g_actual = squash(g_in)
+        g_actual = squash(g_in; kwargs...)
         @test typeof(g_actual) === typeof(g_expected)
         @test g_actual == g_expected
-        if typeof(g_in) === typeof(g_actual)
+        if kwargs == (alwayscopy=false,) && typeof(g_in) === typeof(g_actual)
             @test g_in === g_actual
         end
     end


### PR DESCRIPTION
Related issue: #88 

I did not remove `squash(::AbstractGraph)` as this has the potential of breaking something, even though it is not a good idea to use that  method.

I also changed `squash` for  simple graphs slightly so that it returns the original graph instead of a copy if squashing would not make the graph smaller. 