### PR TITLE
Rng argument for diffusion and diffusion_rate

### DIFF
--- a/src/traversals/diffusion.jl
+++ b/src/traversals/diffusion.jl
@@ -15,16 +15,20 @@ during the simulation. If left empty, all vertices will be watched.
 each of the outneighbors of ``i`` to ``p``. If `true`, set the probability of spread
 from a vertex ``i`` to each of the `outneighbors` of ``i`` to
 ``\\frac{p}{outdegreee(g, i)}``.
+- `rng=GLOBAL_RNG`: A random generator to sample from
 """
 function diffusion(g::AbstractGraph{T},
                     p::Real,
                     n::Integer;
                     watch::AbstractVector=Vector{Int}(),
                     initial_infections::AbstractVector=Graphs.sample(vertices(g), 1),
-                    normalize::Bool=false
+                    normalize::Bool=false,
+                    rng::Union{Nothing, AbstractRNG} = nothing,
+                    seed::Union{Nothing, Integer} = nothing
                     ) where T
 
     # Initialize
+    rng = rng_from_rng_or_seed(rng, seed)
     watch_set = Set{T}(watch)
     infected_vertices = BitSet(initial_infections)
     vertices_per_step::Vector{Vector{T}} = [Vector{T}() for i in 1:n]
@@ -54,7 +58,7 @@ function diffusion(g::AbstractGraph{T},
                     local_p = p
                 end
 
-                randsubseq!(randsubseq_buf, outn, local_p)
+                randsubseq!(rng, randsubseq_buf, outn, local_p)
                 union!(new_infections, randsubseq_buf)
             end
         end
@@ -88,8 +92,10 @@ diffusion_rate(x::Vector{Vector{T}}) where T <: Integer = cumsum(length.(x))
 diffusion_rate(g::AbstractGraph, p::Real, n::Integer;
     initial_infections::AbstractVector=Graphs.sample(vertices(g), 1),
     watch::AbstractVector=Vector{Int}(),
-    normalize::Bool=false
+    normalize::Bool=false,
+    rng::Union{Nothing, AbstractRNG} = nothing,
+    seed::Union{Nothing, Integer} = nothing
     ) = diffusion_rate(diffusion(g, p, n,
             initial_infections=initial_infections,
-            watch=watch, normalize=normalize))
+            watch=watch, normalize=normalize, rng=rng, seed=seed))
 

--- a/test/traversals/diffusion.jl
+++ b/test/traversals/diffusion.jl
@@ -1,11 +1,12 @@
 
 @testset "Diffusion Simulation" begin
 
+rng = MersenneTwister(1234)
 gx = complete_graph(5)
 
 for g in testgraphs(gx)  # this makes graphs of different eltypes
     # Most basic
-    @test @inferred(diffusion_rate(g, 1.0, 4)) == [1, 5, 5, 5]
+    @test @inferred(diffusion_rate(g, 1.0, 4; rng=rng)) == [1, 5, 5, 5]
 end
 
 for i in 1:5
@@ -24,24 +25,28 @@ for g in testgraphs(gx)  # this makes graphs of different eltypes
     # Basic test. Watch connected vertices
     @test @inferred(diffusion_rate(g, 1.0, 4,
                                    watch=collect(1:5),
-                                   initial_infections=[2]
+                                   initial_infections=[2],
+                                   rng=rng
                                    )) == [1, 5, 5, 5]
 
     # Watching unconnected vertices
     @test @inferred(diffusion_rate(g, 1.0, 4,
                                    watch=collect(6:10),
-                                   initial_infections=[2]
+                                   initial_infections=[2],
+                                   rng=rng
                                    )) == [0, 0, 0, 0]
 
     # Watch subset
     @test @inferred(diffusion_rate(g, 1.0, 4,
                                    watch=collect(1:2),
-                                   initial_infections=[2]
+                                   initial_infections=[2],
+                                   rng=rng
                                    )) == [1, 2, 2, 2]
 
     @test @inferred(diffusion_rate(g, 1.0, 4,
                                    watch=collect(1:5),
-                                   initial_infections=[10]
+                                   initial_infections=[10],
+                                   rng=rng
                                    )) == [0, 0, 0, 0]
 
 end
@@ -56,12 +61,14 @@ for g in testgraphs(gx)  # this makes graphs of different eltypes
 
     @test @inferred(diffusion_rate(g, 1.0, 4,
                                    watch=collect(1:5),
-                                   initial_infections=[1]
+                                   initial_infections=[1],
+                                   rng=rng
                                    )) == [1, 2, 3, 4]
 
     @test @inferred(diffusion_rate(g, 1.0, 4,
                                    watch=collect(1:5),
-                                   initial_infections=[3]
+                                   initial_infections=[3],
+                                   rng=rng
                                    )) == [1, 3, 5, 5]
 end
 
@@ -72,14 +79,16 @@ for g in testgraphs(gx)
                                   1.0,
                                   6,
                                   initial_infections=[15],
-                                  normalize=false
+                                  normalize=false,
+                                  rng=rng
                                   )) == [1, 3, 5, 7, 9, 11]
 
 
     @test @inferred(diffusion_rate(g, 2.0, 6,
                                    initial_infections=[15],
-                                   normalize=true)
-                                   ) == [1, 3, 5, 7, 9, 11]
+                                   normalize=true,
+                                   rng=rng
+                                   )) == [1, 3, 5, 7, 9, 11]
 
     # Test probability accurate
     # In a Path network,


### PR DESCRIPTION
This PR adds a random number keyword argument to `diffusion` and `dissusion_rate`, therefore hopefully removing the sporadically failing tests.

It is based on #95 , but Github does not allow me to set this as a master, therefore there appears to be more code in this Pr than there actually is.