### PR TITLE
Make random numbers deterministic for graph matrices tests

### DIFF
--- a/test/linalg/graphmatrices.jl
+++ b/test/linalg/graphmatrices.jl
@@ -2,6 +2,11 @@
 using ArnoldiMethod
 
 @testset "Graph matrices" begin
+
+    # TODO fixing the random number generator is not ideal, but currently
+    # the tests here fail a bit too often when running them in ci/cd.
+    rng = MersenneTwister(1234)
+
     function converttest(T::Type, var)
         @test typeof(T(var)) == T
     end
@@ -176,13 +181,13 @@ using ArnoldiMethod
 
     n = 10
 
-    mat = Float64.(sprand(Bool, n, n, 0.3))
+    mat = Float64.(sprand(rng, Bool, n, n, 0.3))
 
     test_adjacency(mat)
     test_laplacian(mat)
     test_accessors(mat, n)
 
-    mat = symmetrize(Float64.(sprand(Bool, n, n, 0.3)))
+    mat = symmetrize(Float64.(sprand(rng, Bool, n, n, 0.3)))
     test_arithmetic(mat, n)
     test_other(mat, n)
     test_symmetry(mat, n)
@@ -212,7 +217,7 @@ using ArnoldiMethod
     # Random walk demo
     n = 100
     p = 16 / n
-    M = sprand(n, n, p)
+    M = sprand(rng, n, n, p)
     M.nzval[:] .= 1.0
     A = CombinatorialAdjacency(M)
     sd = stationarydistribution(A; mindim=10)


### PR DESCRIPTION
This PR makes the random number generator for graph matrices deterministic. This is not ideal, but at the moment these tests fail a bit too often. Maybe we can come up with some better tests in the future.