### PR TITLE
Update Shortest paths docs

### DIFF
--- a/docs/src/first_steps/paths_traversal.md
+++ b/docs/src/first_steps/paths_traversal.md
@@ -31,7 +31,7 @@ The package also includes uniform random walks and self avoiding walks with the 
 The following properties always hold for shortest path algorithms implemented here:
 
 - The distance from a vertex to itself is always `0`.
-- The distance between two vertices with no connecting edge is always `Inf`.
+- The distance between two vertices with no connecting edge is always `Inf` or `typemax(Int64)`.
 
 The `dijkstra_shortest_paths`, `desopo_pape_shortest_paths`, `floyd_warshall_shortest_paths`, `bellman_ford_shortest_paths`, and `yen_shortest_paths` functions return path states (subtypes of `Graphs.AbstractPathState`) that contain various information about the graph learned during traversal.
 
@@ -43,4 +43,5 @@ The corresponding state types (with the exception of `YenState`) have the follow
 In addition, the following information may be populated with the appropriate arguments to `dijkstra_shortest_paths`:
 
 - `state.predecessors` holds a vector, indexed by vertex, of all the predecessors discovered during shortest-path calculations. This keeps track of all parents when there are multiple shortest paths available from the source.
-- `state.pathcounts` holds a vector, indexed by vertex, of the path counts discovered during traversal. This equals the length of each subvector in the `state.predecessors` output above.
+- `state.pathcounts` holds a vector, indexed by vertex, of the number of shortest paths from the source to that vertex. The path count of a source vertex is always `1.0`. The path count of an unreached vertex is always `0.0`.
+- `state.closest_vertices` holds a vector of all vertices in the graph ordered from closest to farthest.

--- a/docs/src/first_steps/paths_traversal.md
+++ b/docs/src/first_steps/paths_traversal.md
@@ -31,7 +31,7 @@ The package also includes uniform random walks and self avoiding walks with the 
 The following properties always hold for shortest path algorithms implemented here:
 
 - The distance from a vertex to itself is always `0`.
-- The distance between two vertices with no connecting edge is always `Inf` or `typemax(Int64)`.
+- The distance between two vertices with no connecting edge is always `Inf` or `typemax(eltype(distmx))`.
 
 The `dijkstra_shortest_paths`, `desopo_pape_shortest_paths`, `floyd_warshall_shortest_paths`, `bellman_ford_shortest_paths`, and `yen_shortest_paths` functions return path states (subtypes of `Graphs.AbstractPathState`) that contain various information about the graph learned during traversal.
 

--- a/docs/src/first_steps/paths_traversal.md
+++ b/docs/src/first_steps/paths_traversal.md
@@ -33,15 +33,11 @@ The following properties always hold for shortest path algorithms implemented he
 - The distance from a vertex to itself is always `0`.
 - The distance between two vertices with no connecting edge is always `Inf` or `typemax(eltype(distmx))`.
 
-The `dijkstra_shortest_paths`, `desopo_pape_shortest_paths`, `floyd_warshall_shortest_paths`, `bellman_ford_shortest_paths`, and `yen_shortest_paths` functions return path states (subtypes of `Graphs.AbstractPathState`) that contain various information about the graph learned during traversal.
+The [`dijkstra_shortest_paths`](@ref), [`desopo_pape_shortest_paths`](@ref), [`floyd_warshall_shortest_paths`](@ref), [`bellman_ford_shortest_paths`](@ref), and [`yen_k_shortest_paths`](@ref) functions return path states (subtypes of `Graphs.AbstractPathState`) that contain various information about the graph learned during traversal.
 
 The corresponding state types (with the exception of `YenState`) have the following common fields:
 
 - `state.dists` holds a vector with the distances computed, indexed by source vertex.
 - `state.parents` holds a vector of parents of each vertex on the shortest paths (the parent of a source vertex is always `0`). `YenState` substitutes `.paths` for `.parents`.
 
-In addition, the following information may be populated with the appropriate arguments to `dijkstra_shortest_paths`:
-
-- `state.predecessors` holds a vector, indexed by vertex, of all the predecessors discovered during shortest-path calculations. This keeps track of all parents when there are multiple shortest paths available from the source.
-- `state.pathcounts` holds a vector, indexed by vertex, of the number of shortest paths from the source to that vertex. The path count of a source vertex is always `1.0`. The path count of an unreached vertex is always `0.0`.
-- `state.closest_vertices` holds a vector of all vertices in the graph ordered from closest to farthest.
+In addition, with the appropriate optional arguments, [`dijkstra_shortest_paths`](@ref) will return information on all possible shortest paths available from the source.

--- a/src/shortestpaths/dijkstra.jl
+++ b/src/shortestpaths/dijkstra.jl
@@ -18,9 +18,20 @@ Perform [Dijkstra's algorithm](http://en.wikipedia.org/wiki/Dijkstra%27s_algorit
 on a graph, computing shortest distances between `srcs` and all other vertices.
 Return a [`Graphs.DijkstraState`](@ref) that contains various traversal information.
 
+
 ### Optional Arguments
-- `allpaths=false`: If true, returns a [`Graphs.DijkstraState`](@ref) that keeps track of all
-predecessors of a given vertex.
+* `allpaths=false`: If true, 
+
+`state.predecessors` holds a vector, indexed by vertex,
+of all the predecessors discovered during shortest-path calculations.
+This keeps track of all parents when there are multiple shortest paths available from the source.
+
+`state.pathcounts` holds a vector, indexed by vertex, of the number of shortest paths from the source to that vertex. 
+The path count of a source vertex is always `1.0`. The path count of an unreached vertex is always `0.0`.
+
+* `trackvertices=false`: If true, 
+
+`state.closest_vertices` holds a vector of all vertices in the graph ordered from closest to farthest.
 
 ### Performance
 If using a sparse matrix for `distmx`, you *may* achieve better performance by passing in a transpose of its sparse transpose.


### PR DESCRIPTION
I added some details to the Shortest paths section of the docs.

Maybe some of the specific `dijkstra_shortest_paths` info should be moved to `function dijkstra_shortest_paths` docs?