### PR TITLE
Add generic graphs to help with testing

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -528,6 +528,7 @@ include("vertexcover/degree_vertex_cover.jl")
 include("vertexcover/random_vertex_cover.jl")
 include("Experimental/Experimental.jl")
 include("Parallel/Parallel.jl")
+include("Test/Test.jl")
 
 using .LinAlg
 end # module

--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -1,0 +1,82 @@
+
+"""
+    Graphs.Test
+
+A module that provides utilities for testing functions that should work with any `Graphs.AbstractGraph`.
+"""
+module Test
+
+using Graphs
+
+export GenericEdge, GenericGraph, GenericDiGraph
+
+"""
+    GenericEdge <: Graphs.AbstractEdge
+
+An edge type that can  be used to tests functions that relay on the Graphs.jl interface.
+
+"""
+struct GenericEdge{T} <: Graphs.AbstractEdge{T}
+    e::Graphs.SimpleEdge{T}
+end
+
+Graphs.src(e::GenericEdge) = Graphs.src(e.e)
+
+Graphs.dst(e::GenericEdge) = Graphs.dst(e.e)
+
+Base.reverse(e::GenericEdge) = GenericEdge(reverse(e.e))
+
+"""
+    GenericGraph{T} <: Graphs.AbstractGraph{T}
+
+An undirected graph type that can  be used to tests functions that relay on the Graphs.jl interface.
+
+"""
+struct GenericGraph{T} <: Graphs.AbstractGraph{T}
+    g::SimpleGraph{T}
+end
+
+"""
+    GenericDiGraph{T} <: Graphs.AbstractGraph{T}
+
+A directed graph type that can  be used to tests functions that relay on the Graphs.jl interface.
+
+"""
+struct GenericDiGraph{T} <: Graphs.AbstractGraph{T}
+    g::SimpleDiGraph{T}
+end
+
+Graphs.is_directed(::Type{<:GenericGraph}) = false
+Graphs.is_directed(::Type{<:GenericDiGraph}) = true
+
+Base.eltype(g::GenericGraph) = eltype(g.g)
+Base.eltype(g::GenericDiGraph) = eltype(g.g)
+
+Graphs.edges(g::GenericGraph) = (GenericEdge(e) for e in Graphs.edges(g.g))
+Graphs.edges(g::GenericDiGraph) = (GenericEdge(e) for e in Graphs.edges(g.g))
+
+Graphs.edgetype(g::GenericGraph) = GenericEdge{eltype(g)}
+Graphs.edgetype(g::GenericDiGraph) = GenericEdge{eltype(g)}
+
+Graphs.has_edge(g::GenericGraph, s, d) = Graphs.has_edge(g.g, s, d)
+Graphs.has_edge(g::GenericDiGraph, s, d) = Graphs.has_edge(g.g, s, d)
+
+Graphs.has_vertex(g::GenericGraph, v) = Graphs.has_vertex(g.g, v)
+Graphs.has_vertex(g::GenericDiGraph, v) = Graphs.has_vertex(g.g, v)
+
+Graphs.inneighbors(g::GenericGraph, v) = (u for u in Graphs.inneighbors(g.g, v))
+Graphs.inneighbors(g::GenericDiGraph, v) = (u for u in Graphs.inneighbors(g.g, v))
+
+Graphs.outneighbors(g::GenericGraph, v) = (u for u in Graphs.outneighbors(g.g, v))
+Graphs.outneighbors(g::GenericDiGraph, v) = (u for u in Graphs.outneighbors(g.g, v))
+
+Graphs.ne(g::GenericGraph) = Graphs.ne(g.g)
+Graphs.ne(g::GenericDiGraph) = Graphs.ne(g.g)
+
+Graphs.nv(g::GenericGraph) = Graphs.nv(g.g)
+Graphs.nv(g::GenericDiGraph) = Graphs.nv(g.g)
+
+Graphs.vertices(g::GenericGraph) = (v for v in Graphs.vertices(g.g))
+Graphs.vertices(g::GenericDiGraph) = (v for v in Graphs.vertices(g.g))
+
+end # module

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,6 +1,8 @@
 @testset "Core" begin
-    e2 = Edge(1, 3)
-    e3 = Edge(1, 4)
+    e2 = GenericEdge(Edge(1, 3))
+    e3 = GenericEdge(Edge(1, 4))
+    # TODO do these tests make sense? One might define an edge type for some undirected
+    # graph that is more like a set than a tuple -then reverse would not change the order
     @test @inferred(is_ordered(e2))
     @test @inferred(!is_ordered(reverse(e3)))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Graphs
 using Graphs.SimpleGraphs
 using Graphs.Experimental
 using JuliaFormatter
+using Graphs.Test
 using Test
 using SparseArrays
 using LinearAlgebra

--- a/test/traversals/dfs.jl
+++ b/test/traversals/dfs.jl
@@ -25,7 +25,7 @@
     )
     @testset "dfs_tree" begin
         for g in testdigraphs(g5)
-            z = @inferred(dfs_tree(g, 1))
+            z = @inferred(dfs_tree(GenericDiGraph(g), 1))
             @test ne(z) == 3 && nv(z) == 4
             @test !has_edge(z, 1, 3)
             @test !is_cyclic(g)
@@ -34,19 +34,19 @@
 
     @testset "topological_sort_by_dfs" begin
         for g in testdigraphs(g5)
-            @test @inferred(topological_sort_by_dfs(g)) == [1, 2, 3, 4]
+            @test @inferred(topological_sort_by_dfs(GenericDiGraph(g))) == [1, 2, 3, 4]
         end
 
         for g in testdigraphs(gx)
-            @test @inferred(is_cyclic(g))
-            @test_throws ErrorException topological_sort_by_dfs(g)
+            @test @inferred(is_cyclic(GenericDiGraph(g)))
+            @test_throws ErrorException topological_sort_by_dfs(GenericDiGraph(g))
         end
     end
 
     @testset "is_cyclic" begin
         for g in testgraphs(path_graph(2))
-            @test !@inferred(is_cyclic(g))
-            @test !@inferred(is_cyclic(zero(g)))
+            @test !@inferred(is_cyclic(GenericGraph(g)))
+            @test !@inferred(is_cyclic(GenericGraph(zero(g))))
         end
         for g in testgraphs(gcyclic)
             @test @inferred(is_cyclic(g))


### PR DESCRIPTION
Our tests currently almost everywhere use `SimpleGraph` and `SimpleDiGraph` for testing methods that work with `AbstractGraph` and `AbstractEege`.. This can lead to issues, when the  methods under test relay on methods that are defined for `SimpleGraph` and `SimpleDiGraph`, but are not part of the Graphs.jl interface.

This PR therefore adds a submodule `Graphs.Test` and the generic graph types `GenericGraph` and `GenericDiGraph` as well as the generic edge type `GenericEdge` that correspond to the interface, but nothing else. The submodule is located within the `src` and not the `test` directory, so that it can also be used in tests of downstream packages.

The names are inspired from similar structures such as `GenericArray` and `GenericOrder` in the Julia package `Test.jl`.

Mutability is currently not covered, as the interface is also not well defined there - this is something we have to tackle in the future.

I also added the generic types to a few existing tests to demonstrate their functionality - in the future we should also modify other tests to use them.