### PR TITLE
Fix method ambiguity with `sort!(::AbstractVector, ..., ::NOOPSortAlg, ...)`

### DIFF
--- a/src/Experimental/Traversals/bfs.jl
+++ b/src/Experimental/Traversals/bfs.jl
@@ -4,7 +4,7 @@ import Base:sort!
 struct NOOPSortAlg <: Base.Sort.Algorithm end
 const NOOPSort = NOOPSortAlg()
 
-sort!(x, ::Integer, ::Integer, ::NOOPSortAlg, ::Base.Sort.Ordering) = x
+sort!(x::AbstractVector, ::Integer, ::Integer, ::NOOPSortAlg, ::Base.Sort.Ordering) = x
 
 struct BFS{T<:Base.Sort.Algorithm} <: TraversalAlgorithm
     sort_alg::T


### PR DESCRIPTION
The recent upstream commit https://github.com/JuliaLang/julia/pull/45330 introduced a new method for `sort!`. It results in a potential method ambiguity that [Aqua.jl](https://github.com/JuliaTesting/Aqua.jl) detected in the nightly CI of PeriodicGraphEmbeddings.jl (see [here](https://github.com/Liozou/PeriodicGraphEmbeddings.jl/runs/6723951400?check_suite_focus=true)).

So here is a quick fix.

For reference, this `sort!` method was added in https://github.com/JuliaGraphs/Graphs.jl/commit/383eeb311009da655a7d1930f7e918301899f461. It should be safe to reduce the type of its argument `x` to `AbstractVector` since you rarely want to `sort!` anything else in general, and I think this particular method is only ever called in the `traverse_graph!` function in the same file, hence on a `Vector`.