### PR TITLE
Import Graphs in rich_club docstring.

### DIFF
--- a/src/community/rich_club.jl
+++ b/src/community/rich_club.jl
@@ -5,7 +5,7 @@ Return the non-normalised [rich-club coefficient](https://en.wikipedia.org/wiki/
 with degree cut-off `k`.
 
 ```jldoctest
-julia> using LightGraphs
+julia> using Graphs
 julia> g = star_graph(5)
 julia> rich_club(g, 1)
 0.4


### PR DESCRIPTION
The function was ported from a PR originally in the LightGraphs.jl repository. This PR changes the docstring to import Graphs.jl, the correct library.

Since `rich_club` was added to Graphs.jl, but never to LightGraphs.jl, this also removes some potential confusion.