### PR TITLE
Fix loadgraph for Julia v1.8

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -9,7 +9,7 @@ using Statistics: mean
 # Currently used to support the ismutable function that is not available in Julia < v1.7
 using Compat
 
-using Inflate: InflateGzipStream
+using Inflate: inflate_gzip
 using DataStructures: IntDisjointSets, PriorityQueue, dequeue!, dequeue_pair!, enqueue!, heappop!, heappush!, in_same_set, peek, union!, find_root!
 using LinearAlgebra: I, Symmetric, diagm, eigen, eigvals, norm, rmul!, tril, triu
 import LinearAlgebra: Diagonal, issymmetric, mul!

--- a/src/persistence/common.jl
+++ b/src/persistence/common.jl
@@ -52,7 +52,12 @@ function auto_decompress(io::IO)
     end
     reset(io)
     if format == :gzip
-        io = InflateGzipStream(io)
+        # TODO we should use InflateGzipStream here instead of inflate_gzip
+        # so that we can read the file as a stream, but due to a bug
+        # that only appears # from Julia v1.8 on, InflateGzipStream reads incorrect
+        # data from some files.
+        # See: https://github.com/GunnarFarneback/Inflate.jl/issues/10
+        io = IOBuffer(inflate_gzip(read(io)))
     end
     return io
 end


### PR DESCRIPTION
This is a temporary workaround for a bug that only appears from Julia v1.8 on.

See: https://github.com/GunnarFarneback/Inflate.jl/issues/10