### PR TITLE
Bump Inflate dependency to include a bugfix for Julia 1.8.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Graphs"
 uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-version = "1.7.1"
+version = "1.7.2"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
@@ -19,7 +19,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ArnoldiMethod = "0.1, 0.2"
 Compat = "3.40, 4"
 DataStructures = "0.17, 0.18"
-Inflate = "0.1.2"
+Inflate = "0.1.3"
 SimpleTraits = "0.9"
 julia = "1.6"
 


### PR DESCRIPTION
Use upstream bugfix instead of the #164 workaround.