### PR TITLE
Fix markdown in doctest

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -275,7 +275,7 @@ julia> all_neighbors(g, 3)
 2-element Array{Int64,1}:
  1
  2
- ```
+```
 """
 function all_neighbors end
 @traitfn all_neighbors(g::::IsDirected, v::Integer) =


### PR DESCRIPTION
Fix a small parsing issue in the doc string for `all_neighbors` which caused the julia block to not render correctly in the docs.

![graphs_docs](https://user-images.githubusercontent.com/6856636/193447660-4683292a-6c40-40bb-a870-1828cb0df559.jpg)
