### PR TITLE
fixed typos

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -185,7 +185,7 @@ vertices(g::AbstractGraph) = _NI("vertices")
 
 Return (an iterator to or collection of) the edges of a graph.
 For `AbstractSimpleGraph`s it returns a `SimpleEdgeIter`.
-The expressions `e in edges(g)` and `e ∈ edges(ga)` evaluate as
+The expressions `e in edges(g)` and `e ∈ edges(g)` evaluate as
 calls to [`has_edge`](@ref).
 
 ### Implementation Notes
@@ -255,7 +255,7 @@ Return true if the graph `g` has an edge from node `s` to node `d`.
 An optional `has_edge(g, e)` can be implemented to check if an edge belongs
 to a graph, including any data other than source and destination node.
 
-`e ∈ edges(g)` or `e ∈ edges(g)` evaluate as
+`e in edges(g)` or `e ∈ edges(g)` evaluate as
 calls to `has_edge`, c.f. [`edges`](@ref).
 
 # Examples


### PR DESCRIPTION
I fixed the following typos:
`ga` in `g`
![image](https://user-images.githubusercontent.com/65721467/194707807-a5099039-aff3-476a-9a1a-245627c54921.png)
and the repetition 
```Julia
e ∈ edges(g) or e ∈ edges(g)
```
in
```Julia
e in edges(g) or e ∈ edges(g)
```
![image](https://user-images.githubusercontent.com/65721467/194707912-ff29795b-df69-47b4-bd1f-51db931b07a3.png)
