### PR TITLE
Change test outputs 

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,9 +92,9 @@ tests = [
     "experimental/experimental"
 ]
 
-@testset "Graphs" begin
+@testset verbose=true "Graphs" begin
     for t in tests
         tp = joinpath(testdir, "$(t).jl")
         include(tp)
     end
-end
+end;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,7 @@ tests = [
     "experimental/experimental"
 ]
 
-@testset verbose=true "Graphs" begin
+@testset verbose = true "Graphs" begin
     for t in tests
         tp = joinpath(testdir, "$(t).jl")
         include(tp)


### PR DESCRIPTION
As I wrote in issue #181, the test outputs were hiding the summary table. 
With this pull request I hid the long outputs and I set `verbose = true` to have more readable information in the summary table.