### PR TITLE
Random Cayley trees 

### DIFF
--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1422,3 +1422,9 @@ function random_orientation_dag(
     end
     return g2
 end
+
+"""
+    random_tree(n)
+
+Generate a uniform random tree with n vertices. Each of the n^{n-2} trees have the same probability . 
+"""


### PR DESCRIPTION
Hi everyone, inexperienced contributor here.

I would like to add to `Graphs.jl` some utilities for generating a uniform random tree with $n$ vertices (there are $n^{n-2}$ such trees). 

1) The simplest way of doing so is by Prufer decoding a random word of length n-2 with letters in {1,...,n}. However, it seems that `Graphs.jl` does not have implemented yet Prufer coding/decoding. 

2) Another way of doing so is to generate a spanning tree (using Kruskal for example) of the complete graph with random weights. 

Method 2 is almost immediate to implement since spanning trees algorithms were already implemented in `Graphs.jl`, but I feel like having Prufer coding/decoding should be a very good addition to the package. 

What do you think? 

Also, prufer encoding is available on [this package called `SimpleGraphs.jl`](https://docs.juliahub.com/SimpleGraphs/OBXhI/0.7.14/autodocs/) but it looks like it has nothing to do with the JuliaGraphs ecosystem, or am I wrong here? Is there a way to merge their implementation in `Graphs.jl` ?