### PR TITLE
Remove parenthesis in runtests.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ const testdir = dirname(@__FILE__)
 end
 
 @testset verbose = true "Code formatting (JuliaFormatter.jl)" begin
-    @test format(Graphs; verbose=false, overwrite=false, ignore=["vf2.jl"])  # TODO: remove ignore kwarg once the file is formatted correctly
+    @test format(Graphs; verbose=false, overwrite=false, ignore="vf2.jl")  # TODO: remove ignore kwarg once the file is formatted correctly
 end
 
 @testset verbose = true "Doctests (Documenter.jl)" begin


### PR DESCRIPTION
This PR solves the error that appeared [here](https://github.com/JuliaGraphs/Graphs.jl/actions/runs/3833904977/jobs/6537425873) and which also happened to me.
It is solved by removing the parentheses in the runtests.jl file: `ignore = ["vf2.jl"]` --> `ignore = "vf2.jl"`