### PR TITLE
Fix topological_sort

### DIFF
--- a/src/Experimental/Traversals/Traversals.jl
+++ b/src/Experimental/Traversals/Traversals.jl
@@ -5,7 +5,6 @@ module Traversals
 # to create new graph algorithms that rely on breadth-first or depth-first search traversals.
 
 using Graphs
-import ..Graphs: topological_sort
 using SimpleTraits
 """
     abstract type TraversalAlgorithm
@@ -204,6 +203,6 @@ function tree(
     return tree(p)
 end
 
-export visited_vertices, parents, distances, topological_sort, tree
+export visited_vertices, parents, distances, tree
 
 end  # module

--- a/src/Experimental/Traversals/dfs.jl
+++ b/src/Experimental/Traversals/dfs.jl
@@ -76,6 +76,7 @@ end
     return true
 end
 
+# TODO this function might return incorrect result (see tests) - use Graphs.topological_sort instead
 @traitfn function topological_sort(g::AG::IsDirected) where {T,AG<:AbstractGraph{T}}
     vcolor = zeros(UInt8, nv(g))
     verts = Vector{T}()

--- a/src/traversals/dfs.jl
+++ b/src/traversals/dfs.jl
@@ -60,6 +60,21 @@ end
     return false
 end
 
+"""
+    topological_sort(g)
+
+Return a [topological sort](https://en.wikipedia.org/wiki/Topological_sorting) of a directed
+graph `g` as a vector of vertices in topological order.
+
+### Implementation Notes
+This is currently just an alias for `topological_sort_by_dfs`
+"""
+function topological_sort end
+
+@traitfn function topological_sort(g::AG::IsDirected) where {AG<:AbstractGraph}
+    return topological_sort_by_dfs(g)
+end
+
 # Topological sort using DFS
 """
     topological_sort_by_dfs(g)

--- a/test/experimental/traversals.jl
+++ b/test/experimental/traversals.jl
@@ -112,7 +112,7 @@ struct DummyTraversalState <: LET.AbstractTraversalState end
 
                 ts1 = @inferred LET.topological_sort(dg)
                 @test ts1 == [1, 3, 7, 6, 2, 5, 4]
-                @test_throws LET.CycleError topological_sort(dg2)
+                @test_throws LET.CycleError LET.topological_sort(dg2)
 
                 t1 = @inferred LET.tree(dg, 2, d)
                 t2 = @inferred LET.tree(p1)
@@ -121,6 +121,9 @@ struct DummyTraversalState <: LET.AbstractTraversalState end
                 @test !LET.is_cyclic(dg1)
                 @test LET.is_cyclic(dg2)
             end
+
+            # Currently there is an error in Traverals.topological_sort, so this test fails
+            @test LET.topological_sort(SimpleDiGraph([Edge(2, 1)])) == [2, 1] broken = true
         end
     end
 end

--- a/test/experimental/traversals.jl
+++ b/test/experimental/traversals.jl
@@ -123,7 +123,7 @@ struct DummyTraversalState <: LET.AbstractTraversalState end
             end
 
             # Currently there is an error in Traverals.topological_sort, so this test fails
-            @test LET.topological_sort(SimpleDiGraph([Edge(2, 1)])) == [2, 1] broken = true
+            @test_broken LET.topological_sort(SimpleDiGraph([Edge(2, 1)])) == [2, 1]
         end
     end
 end

--- a/test/traversals/dfs.jl
+++ b/test/traversals/dfs.jl
@@ -32,18 +32,18 @@
         end
     end
 
-    @testset "topological_sort_by_dfs" begin
+    @testset "topological_sort" begin
         for g in testdigraphs(SimpleDiGraph([Edge(2, 1)]))
-            @test @inferred(topological_sort_by_dfs(g)) == [2, 1]
+            @test @inferred(topological_sort(g)) == [2, 1]
         end
 
         for g in testdigraphs(g5)
-            @test @inferred(topological_sort_by_dfs(g)) == [1, 2, 3, 4]
+            @test @inferred(topological_sort(g)) == [1, 2, 3, 4]
         end
 
         for g in testdigraphs(gx)
             @test @inferred(is_cyclic(g))
-            @test_throws ErrorException topological_sort_by_dfs(g)
+            @test_throws ErrorException topological_sort(g)
         end
     end
 

--- a/test/traversals/dfs.jl
+++ b/test/traversals/dfs.jl
@@ -33,6 +33,21 @@
     end
 
     @testset "topological_sort_by_dfs" begin
+        for g in testdigraphs(SimpleDiGraph([Edge(2, 1)]))
+            @test @inferred(topological_sort_by_dfs(g)) == [2, 1]
+        end
+
+        for g in testdigraphs(g5)
+            @test @inferred(topological_sort_by_dfs(g)) == [1, 2, 3, 4]
+        end
+
+        for g in testdigraphs(gx)
+            @test @inferred(is_cyclic(g))
+            @test_throws ErrorException topological_sort_by_dfs(g)
+        end
+    end
+
+    @testset "topological_sort_by_dfs" begin
         for g in testdigraphs(g5)
             @test @inferred(topological_sort_by_dfs(g)) == [1, 2, 3, 4]
         end


### PR DESCRIPTION
`Graphs.Experimental.Traversals.topological_sort` is broken (see #213 ). This PR ensures that `Graphs.Experimental.Traversals.topological_sort` is not exported anymore and makes `Graphs.topological_sort`
an alias for  `Graphs.topological_sort_by_dfs`, as this function seems to work correctly.