### PR TITLE
Fix could not import Graphs.prufer_decode warning

### DIFF
--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -36,8 +36,7 @@ import Graphs:
     num_self_loops,
     insorted,
     squash,
-    rng_from_rng_or_seed,
-    prufer_decode
+    rng_from_rng_or_seed
 
 export AbstractSimpleGraph,
     AbstractSimpleEdge,


### PR DESCRIPTION
There was an incorrect import statement for `prufer_code` in the `SimpleGraphs` submodule. This PR removes it.