### PR TITLE
setting zero values in distmx with zero(T)

### DIFF
--- a/src/shortestpaths/bellman-ford.jl
+++ b/src/shortestpaths/bellman-ford.jl
@@ -41,7 +41,7 @@ function bellman_ford_shortest_paths(
     active[sources] .= true
     dists = fill(typemax(T), nvg)
     parents = zeros(U, nvg)
-    dists[sources] .= 0
+    dists[sources] .= zero(T)
     no_changes = false
     new_active = falses(nvg)
 

--- a/test/shortestpaths/bellman-ford.jl
+++ b/test/shortestpaths/bellman-ford.jl
@@ -41,4 +41,37 @@
         @test_throws Graphs.NegativeCycleError bellman_ford_shortest_paths(g, 1, d)
         @test has_negative_edge_cycle(g, d)
     end
+
+    # setting zeros with zero(T)
+    struct CustomReal <: Real
+        val::Float64
+        bias::Int  # need this, to avoid auto conversion of CustomReal(0)
+    end
+    Base.zero(::T) where {T<:CustomReal} = zero(T)
+    Base.zero(::Type{CustomReal}) = CustomReal(0.0, 4)
+    Base.typemax(::T) where {T<:CustomReal} = typemax(T)
+    Base.typemax(::Type{CustomReal}) = CustomReal(typemax(Float64), 0)
+    Base.:+(a::CustomReal, b::CustomReal) = CustomReal(a.val + b.val, 0)
+    Base.:<(a::CustomReal, b::CustomReal) = a.val < b.val
+
+    d3 = [CustomReal(i, 3) for i in d1]
+    d4 = sparse(d3)
+    for g in testdigraphs(g4)
+        y = @inferred(bellman_ford_shortest_paths(g, 2, d3))
+        z = @inferred(bellman_ford_shortest_paths(g, 2, d4))
+        @test getfield.(y.dists, :val) == getfield.(z.dists, :val) == [Inf, 0, 6, 17, 33]
+        @test @inferred(enumerate_paths(z))[2] == []
+        @test @inferred(enumerate_paths(z))[4] == enumerate_paths(z, 4) == [2, 3, 4]
+        @test @inferred(!has_negative_edge_cycle(g))
+        @test @inferred(!has_negative_edge_cycle(g, d3))
+
+        y = @inferred(bellman_ford_shortest_paths(g, 2, d3))
+        z = @inferred(bellman_ford_shortest_paths(g, 2, d4))
+        @test getfield.(y.dists, :val) == getfield.(z.dists, :val) == [Inf, 0, 6, 17, 33]
+        @test @inferred(enumerate_paths(z))[2] == []
+        @test @inferred(enumerate_paths(z))[4] == enumerate_paths(z, 4) == [2, 3, 4]
+        @test @inferred(!has_negative_edge_cycle(g))
+        z = @inferred(bellman_ford_shortest_paths(g, 2))
+        @test z.dists == [typemax(Int), 0, 1, 2, 3]
+    end
 end


### PR DESCRIPTION
Just fixing a small inconsistency in the source of `bellman_ford_shortest_paths`, where the zero values have been set by the Integer value rather than the `zero` function of the respective type.