### PR TITLE
Fix `adjacency_matrix` when `dir=:both`

### DIFF
--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -57,15 +57,12 @@ function _adjacency_matrix(
     for j in 1:n_v  # this is by column, not by row.
         if has_edge(g, j, j)
             push!(selfloops, j)
-            if !(T <: Bool) && !is_directed(g)
-                nz -= 1
-            end
         end
         dsts = sort(collect(neighborfn(g, j))) # TODO for most graphs it might not be necessary to sort
         colpt[j + 1] = colpt[j] + length(dsts)
         append!(rowval, dsts)
     end
-    spmx = SparseMatrixCSC(n_v, n_v, colpt, rowval, ones(T, nz))
+    spmx = SparseMatrixCSC(n_v, n_v, colpt, rowval, ones(T, length(rowval)))
 
     # this is inefficient. There should be a better way of doing this.
     # the issue is that adjacency matrix entries for self-loops are 2,

--- a/test/linalg/spectral.jl
+++ b/test/linalg/spectral.jl
@@ -186,4 +186,12 @@ Matrix(nbt::Nonbacktracking) = Matrix(sparse(nbt))
             @test spectral_distance(g, g, 1) ≈ 0 atol = 1e-8
         end
     end
+
+    @testset "adjacency_matrix with `dir=:both`" begin
+        edges = [Edge(1, 3), Edge(1, 4), Edge(2, 1), Edge(4, 1)]
+        g = SimpleDiGraph(edges)
+        @test all(adjacency_matrix(g; dir=:out) .== [0 0 1 1; 1 0 0 0; 0 0 0 0; 1 0 0 0])
+        @test all(adjacency_matrix(g; dir=:in) .== [0 1 0 1; 0 0 0 0; 1 0 0 0; 1 0 0 0])
+        @test all(adjacency_matrix(g; dir=:both) .== [0 1 1 1; 1 0 0 0; 1 0 0 0; 1 0 0 0])
+    end
 end


### PR DESCRIPTION
fixes #228.
As I mentioned [here](https://github.com/JuliaGraphs/Graphs.jl/issues/228#issuecomment-1435938916), I used `nz` as an upper bound on the capacity of `rowval` .