### PR TITLE
create functions for constructing SimpleGraph and SimpleDiGraph from …

### DIFF
--- a/src/SimpleGraphs/simpledigraph.jl
+++ b/src/SimpleGraphs/simpledigraph.jl
@@ -26,6 +26,31 @@ end
 
 eltype(x::SimpleDiGraph{T}) where {T} = T
 
+# SimpleDiGraph(g)
+"""
+    SimpleDiGraph{T}(g::AbstractGraph)
+
+Construct a `SimpleDiGraph{T}` from an `AbstractGraph`. 
+If `g` is undirected, then every undirected edge x - y in `g` is added 
+as two directed edges x -> y and y -> x.
+"""
+SimpleDiGraph(g::AbstractGraph) = SimpleDiGraph{Int}(g)
+
+function SimpleDiGraph{T}(g::AbstractGraph) where {T<:Integer}
+    simpleDiGraph = SimpleDiGraph(nv(g))
+    if !is_directed(g)
+        @inbounds for e in edges(g)
+            add_edge!(simpleDiGraph, src(e), dst(e))
+            add_edge!(simpleDiGraph, dst(e), src(e))
+        end
+    else
+        @inbounds for e in edges(g)
+            add_edge!(simpleDiGraph, src(e), dst(e))
+        end
+    end
+    return simpleDiGraph
+end
+
 # DiGraph{UInt8}(6), DiGraph{Int16}(7), DiGraph{Int8}()
 """
     SimpleDiGraph{T}(n=0)

--- a/src/SimpleGraphs/simplegraph.jl
+++ b/src/SimpleGraphs/simplegraph.jl
@@ -21,6 +21,26 @@ end
 
 eltype(x::SimpleGraph{T}) where {T} = T
 
+# SimpleGraph(g)
+"""
+    SimpleGraph{T}(g::AbstractGraph)
+
+Construct a `SimpleGraph{T}` from an `AbstractGraph`. 
+If `g` is a `SimpleDiGraph`, then every directed edge in `g` is 
+added as an undirected edge.
+"""
+SimpleGraph(g::AbstractGraph) = SimpleGraph{Int}(g)
+
+# SimpleGraph{UInt8}(g)
+function SimpleGraph{T}(g::AbstractGraph) where {T<:Integer}
+    simpleGraph = SimpleGraph(nv(g))
+    @inbounds for e in edges(g)
+        # it seems that the `add_edge` function already handles multiple edges efficiently (e.g. in the case of directed edges 1 -> 2 and 2 -> 1).
+        add_edge!(simpleGraph, src(e), dst(e))
+    end
+    return simpleGraph
+end
+
 # Graph{UInt8}(6), Graph{Int16}(7), Graph{UInt8}()
 """
     SimpleGraph{T}(n=0)

--- a/test/simplegraphs/simplegraphs.jl
+++ b/test/simplegraphs/simplegraphs.jl
@@ -498,4 +498,145 @@ using Random: Random
     end
     # codecov for has_edge(::AbstractSimpleGraph, x, y)
     @test @inferred has_edge(DummySimpleGraph(), 1, 2)
+
+    @testset "Construct SimpleGraph from AbstractGraph" begin
+        # Test empty generic graph conversion to SimpleGraph
+        h1 = GenericGraph(SimpleGraph())
+        h2 = GenericDiGraph(SimpleDiGraph())
+        h3 = GenericGraph{UInt128}(SimpleGraph{UInt128}())
+        h4 = GenericDiGraph{UInt128}(SimpleDiGraph{UInt128}())
+
+        genericH1ToSimpleGraph = SimpleGraph(h1)
+        genericH2ToSimpleGraph = SimpleGraph(h2)
+        genericH3ToSimpleGraph = SimpleGraph(h3)
+        genericH4ToSimpleGraph = SimpleGraph(h4)
+
+        # Test properties
+        @test isvalid_simplegraph(genericH1ToSimpleGraph)
+        @test isvalid_simplegraph(genericH2ToSimpleGraph)
+        @test @inferred(!is_directed(genericH1ToSimpleGraph))
+        @test @inferred(!is_directed(genericH2ToSimpleGraph))
+        @test @inferred(!is_directed(genericH3ToSimpleGraph))
+        @test @inferred(!is_directed(genericH4ToSimpleGraph))
+        @test isvalid_simplegraph(genericH3ToSimpleGraph)
+        @test isvalid_simplegraph(genericH4ToSimpleGraph)
+        @test nv(genericH1ToSimpleGraph) == 0
+        @test nv(genericH2ToSimpleGraph) == 0
+        @test nv(genericH3ToSimpleGraph) == 0
+        @test nv(genericH4ToSimpleGraph) == 0
+        @test ne(genericH1ToSimpleGraph) == 0
+        @test ne(genericH2ToSimpleGraph) == 0
+        @test ne(genericH3ToSimpleGraph) == 0
+        @test ne(genericH4ToSimpleGraph) == 0
+        @test @inferred(eltype(h3)) == UInt128
+        @test @inferred(eltype(h4)) == UInt128
+
+        # Test GenericGraph conversion to SimpleGraph
+        h1 = SimpleGraph(3)
+        add_edge!(h1, 1, 2)
+        add_edge!(h1, 2, 3)
+
+        genericH1 = GenericGraph(h1)
+        genericH1ToSimpleGraph = SimpleGraph(genericH1)
+
+        # Test properties
+        @test isvalid_simplegraph(genericH1ToSimpleGraph)
+        @test nv(genericH1ToSimpleGraph) == 3
+        @test ne(genericH1ToSimpleGraph) == 2
+        @test @inferred(eltype(genericH1ToSimpleGraph)) == Int
+        @test Edge(1, 2) in edges(genericH1ToSimpleGraph)
+        @test Edge(2, 3) in edges(genericH1ToSimpleGraph)
+
+        # Test GenericDiGraph conversion to SimpleGraph
+        h2 = SimpleDiGraph(3)
+        # add directed edges 1 -> 2 and 2 -> 1 and test that only one undirected edge is added
+        add_edge!(h2, 1, 2)
+        add_edge!(h2, 2, 1)
+        # add directed edge 1 -> 3 and test that the undirected edge 1 - 3 is added.
+        add_edge!(h2, 1, 3)
+
+        genericH2 = GenericDiGraph(h2)
+        genericH2ToSimpleGraph = SimpleGraph(genericH2)
+
+        # Test properties
+        @test isvalid_simplegraph(genericH1ToSimpleGraph)
+        @test nv(genericH2ToSimpleGraph) == 3
+        @test ne(genericH2) == 3
+        @test ne(genericH2ToSimpleGraph) == 2
+        @test @inferred(eltype(genericH2ToSimpleGraph)) == Int
+        @test Edge(1, 2) in edges(genericH2ToSimpleGraph)
+        @test Edge(1, 3) in edges(genericH2ToSimpleGraph)
+    end
+
+    @testset "Construct SimpleDiGraph from AbstractGraph" begin
+         # Test empty generic graph conversion to SimpleDiGraph
+         h1 = GenericGraph(SimpleGraph())
+         h2 = GenericDiGraph(SimpleDiGraph())
+         h3 = GenericGraph{UInt128}(SimpleGraph{UInt128}())
+         h4 = GenericDiGraph{UInt128}(SimpleDiGraph{UInt128}())
+ 
+         genericH1ToSimpleGraph = SimpleDiGraph(h1)
+         genericH2ToSimpleGraph = SimpleDiGraph(h2)
+         genericH3ToSimpleGraph = SimpleDiGraph(h3)
+         genericH4ToSimpleGraph = SimpleDiGraph(h4)
+ 
+         # Test properties
+         @test isvalid_simplegraph(genericH1ToSimpleGraph)
+         @test isvalid_simplegraph(genericH2ToSimpleGraph)
+         @test @inferred(is_directed(genericH1ToSimpleGraph))
+         @test @inferred(is_directed(genericH2ToSimpleGraph))
+         @test @inferred(is_directed(genericH3ToSimpleGraph))
+         @test @inferred(is_directed(genericH4ToSimpleGraph))
+         @test isvalid_simplegraph(genericH3ToSimpleGraph)
+         @test isvalid_simplegraph(genericH4ToSimpleGraph)
+         @test nv(genericH1ToSimpleGraph) == 0
+         @test nv(genericH2ToSimpleGraph) == 0
+         @test nv(genericH3ToSimpleGraph) == 0
+         @test nv(genericH4ToSimpleGraph) == 0
+         @test ne(genericH1ToSimpleGraph) == 0
+         @test ne(genericH2ToSimpleGraph) == 0
+         @test ne(genericH3ToSimpleGraph) == 0
+         @test ne(genericH4ToSimpleGraph) == 0
+         @test @inferred(eltype(h3)) == UInt128
+         @test @inferred(eltype(h4)) == UInt128
+ 
+         # Test GenericGraph conversion to SimpleDiGraph
+         h1 = SimpleGraph(3)
+         add_edge!(h1, 1, 2)
+         add_edge!(h1, 2, 3)
+ 
+         genericH1 = GenericGraph(h1)
+         genericH1ToSimpleGraph = SimpleDiGraph(genericH1)
+ 
+         # Test properties
+         @test isvalid_simplegraph(genericH1ToSimpleGraph)
+         @test nv(genericH1ToSimpleGraph) == 3
+         # two directed edges for each undirected edge
+         @test ne(genericH1ToSimpleGraph) == 4
+         @test @inferred(eltype(genericH1ToSimpleGraph)) == Int
+         @test Edge(1, 2) in edges(genericH1ToSimpleGraph)
+         @test Edge(2, 1) in edges(genericH1ToSimpleGraph)
+         @test Edge(2, 3) in edges(genericH1ToSimpleGraph)
+         @test Edge(3, 2) in edges(genericH1ToSimpleGraph)
+ 
+         # Test GenericDiGraph conversion to SimpleGraph
+         h2 = SimpleDiGraph(3)
+         # add directed edges 1 -> 2 and 2 -> 1 and test that only one undirected edge is added
+         add_edge!(h2, 1, 2)
+         add_edge!(h2, 2, 1)
+         # add directed edge 1 -> 3 and test that the undirected edge 1 - 3 is added.
+         add_edge!(h2, 1, 3)
+ 
+         genericH2 = GenericDiGraph(h2)
+         genericH2ToSimpleGraph = SimpleDiGraph(genericH2)
+ 
+         # Test properties
+         @test isvalid_simplegraph(genericH1ToSimpleGraph)
+         @test nv(genericH2ToSimpleGraph) == 3
+         @test ne(genericH2ToSimpleGraph) == 3
+         @test @inferred(eltype(genericH2ToSimpleGraph)) == Int
+         @test Edge(1, 2) in edges(genericH2ToSimpleGraph)
+         @test Edge(2, 1) in edges(genericH2ToSimpleGraph)
+         @test Edge(1, 3) in edges(genericH2ToSimpleGraph)
+    end
 end


### PR DESCRIPTION
I have tried to implement [#98](https://github.com/JuliaGraphs/Graphs.jl/issues/98).  In particular, I have decided to create an undirected edge if their appears to be an directed edge if one tries to construct a `SimpleGraph` from an `AbstractGraph` that happens to be directed in order to be consistent for the already existing constructor for constructing a `SimpleGraph` from a `SimpleDiGraph`.

Moreover, if one tries to construct a `SimpleDiGraph` from an `AbstractGraph` that happens to be undirected, then two directed edges will be added.

This is my first time contributing to a Julia package, so I appreciate any comment or suggestion regarding code style.

I wasn't sure if using the `add_edge` function is sufficient (or efficient), so I might need to implement this differently if you have any suggestions.

I also added a few tests , but there may still be cases here that I have not considered.