### PR TITLE
fix doctests

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,8 +1,12 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.2"
+julia_version = "1.9.0-rc2"
 manifest_format = "2.0"
 project_hash = "4fb688147559360c201b0f727fe4bd07d6143f40"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
 
 [[deps.ArnoldiMethod]]
 deps = ["LinearAlgebra", "Random", "StaticArrays"]
@@ -25,7 +29,7 @@ version = "4.4.0"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.5.2+0"
+version = "1.0.2+0"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -53,11 +57,19 @@ git-tree-sha1 = "3ebb967819b284dc1e3c0422229b58a40a255649"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "0.26.3"
 
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
 [[deps.Graphs]]
 deps = ["ArnoldiMethod", "Compat", "DataStructures", "Distributed", "Inflate", "LinearAlgebra", "Random", "SharedArrays", "SimpleTraits", "SparseArrays", "Statistics"]
 path = ".."
 uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-version = "1.7.4"
+version = "1.8.0"
 
 [[deps.IOCapture]]
 deps = ["Logging"]
@@ -80,15 +92,30 @@ git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.3"
 
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.84.0+0"
+
 [[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.10.2+0"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[deps.LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.Logging]]
@@ -104,8 +131,17 @@ version = "0.5.10"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+0"
+
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.10.11"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -114,7 +150,7 @@ version = "1.2.0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.20+0"
+version = "0.3.21+4"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
@@ -126,6 +162,11 @@ deps = ["Dates", "SnoopPrecompile"]
 git-tree-sha1 = "b64719e8b4504983c7fca6cc9db3ebc8acc2a4d6"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.5.1"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.9.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -165,7 +206,7 @@ version = "1.0.1"
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[deps.SparseArrays]]
-deps = ["LinearAlgebra", "Random"]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[deps.StaticArrays]]
@@ -182,6 +223,22 @@ version = "1.4.0"
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.9.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "Pkg", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "5.10.1+6"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -194,7 +251,22 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+0"
+
 [[deps.libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.1.1+0"
+version = "5.4.0+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.48.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+0"

--- a/src/Experimental/ShortestPaths/ShortestPaths.jl
+++ b/src/Experimental/ShortestPaths/ShortestPaths.jl
@@ -181,7 +181,9 @@ algorithm `alg` (one of [`BellmanFord`](@ref) or [`SPFA`](@ref)), return
 `true` if any cycle detected in the graph has a negative weight.
 # Examples
 
-```jldoctest
+```
+julia> using Graphs
+
 julia> g = complete_graph(3);
 
 julia> d = [1 -3 1; -3 1 1; 1 1 1];

--- a/src/Experimental/ShortestPaths/spfa.jl
+++ b/src/Experimental/ShortestPaths/spfa.jl
@@ -80,7 +80,9 @@ end
 Function which returns true if there is any negative weight cycle in the graph.
 # Examples
 
-```jldoctest
+```
+julia> using Graphs
+
 julia> g = complete_graph(3);
 
 julia> d = [1 -3 1; -3 1 1; 1 1 1];

--- a/src/SimpleGraphs/generators/euclideangraphs.jl
+++ b/src/SimpleGraphs/generators/euclideangraphs.jl
@@ -6,7 +6,9 @@ and return a Euclidean graph, a map containing the distance on each edge and
 a matrix with the points' positions.
 
 ## Examples
-```jldoctest
+```
+julia> using Graphs
+
 julia> g, dists = euclidean_graph(5, 2, cutoff=0.3);
 
 julia> g
@@ -52,7 +54,9 @@ For `p=2` we have the standard Euclidean distance.
 Set `bc=:periodic` to impose periodic boundary conditions in the box ``[0,L]^d``.
 
 ## Examples
-```jldoctest
+```
+julia> using Graphs
+
 julia> pts = rand(3, 10); # 10 vertices in R^3
 
 julia> g, dists = euclidean_graph(pts, p=1, bc=:periodic) # Taxicab-distance (L^1);

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -15,6 +15,8 @@ If not specified, the element type `T` is the type of `nv`.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> SimpleGraph(5, 7)
 {5, 7} undirected simple Int64 graph
 ```
@@ -63,6 +65,8 @@ If not specified, the element type `T` is the type of `nv`.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> SimpleDiGraph(5, 7)
 {5, 7} directed simple Int64 graph
 ```
@@ -135,9 +139,14 @@ probability `p`.
 - `seed=nothing`: set the RNG seed.
 
 # Examples
-```jldoctest
+```
+julia> using Graphs
+
 julia> erdos_renyi(10, 0.5)
 {10, 20} undirected simple Int64 graph
+```
+```jldoctest
+julia> using Graphs
 
 julia> erdos_renyi(10, 0.5, is_directed=true, seed=123)
 {10, 49} directed simple Int64 graph
@@ -173,6 +182,8 @@ graph with `n` vertices and `ne` edges.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> erdos_renyi(10, 30)
 {10, 30} undirected simple Int64 graph
 
@@ -213,8 +224,10 @@ from the expected values are likely.
 - Efficient Generation of Networks with Given Expected Degrees, Joel C. Miller and Aric Hagberg. [https://doi.org/10.1007/978-3-642-21286-4_10](https://doi.org/10.1007/978-3-642-21286-4_10)
 
 # Examples
-```jldoctest
+```
 # 1)
+julia> using Graphs
+
 julia> g = expected_degree_graph([3, 1//2, 1//2, 1//2, 1//2])
 {5, 3} undirected simple Int64 graph
 
@@ -303,6 +316,8 @@ be rewired randomly.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> watts_strogatz(10, 4, 0.3)
 {10, 20} undirected simple Int64 graph
 
@@ -402,11 +417,16 @@ enough `p` and `k`, this should not deviate much from the original model.
 ### Optional Arguments
 - `is_directed=false`: if true, return a directed graph.
 - `rng=nothing`: set the Random Number Generator.
+- `seed=nothing`: set the RNG seed.
 
 ## Examples
-```jldoctest
+```
+julia> using Graphs
+
 julia> newman_watts_strogatz(10, 4, 0.3)
 {10, 26} undirected simple Int64 graph
+````
+```jldoctest
 
 julia> newman_watts_strogatz(Int8(10), 4, 0.8, is_directed=true, seed=123)
 {10, 36} directed simple Int8 graph
@@ -421,8 +441,9 @@ function newman_watts_strogatz(
     β::Real;
     is_directed::Bool=false,
     rng::Union{Nothing,AbstractRNG}=nothing,
+    seed::Union{Nothing,Integer}=nothing,
 )
-    return watts_strogatz(n, k, β; is_directed=is_directed, remove_edges=false, rng=rng)
+    return watts_strogatz(n, k, β; is_directed=is_directed, remove_edges=false, rng=rng, seed=seed)
 end
 
 function _suitable(edges::Set{SimpleEdge{T}}, potential_edges::Dict{T,T}) where {T<:Integer}
@@ -494,6 +515,8 @@ Initial graphs are undirected and consist of isolated vertices by default.
 - `seed=nothing`: set the RNG seed.
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> barabasi_albert(50, 3)
 {50, 141} undirected simple Int64 graph
 
@@ -520,6 +543,8 @@ Initial graphs are undirected and consist of isolated vertices by default.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> barabasi_albert(10, 3, 2)
 {10, 14} undirected simple Int64 graph
 
@@ -559,6 +584,8 @@ already present in the system by preferential attachment.
 - `seed=nothing`: set the RNG seed.
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = cycle_graph(4)
 {4, 4} undirected simple Int64 graph
 
@@ -657,17 +684,31 @@ Time complexity is ``\\mathcal{O}(|V| + |E| log |E|)``.
 - Goh K-I, Kahng B, Kim D: Universal behaviour of load distribution in scale-free networks. Phys Rev Lett 87(27):278701, 2001.
 
 ## Examples
-```jldoctest
+```
 julia> g = static_fitness_model(5, [1, 1, 0.5, 0.1])
 {4, 5} undirected simple Int64 graph
 
 julia> edges(g) |> collect
-5-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+5-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 3
  Edge 1 => 4
  Edge 2 => 3
  Edge 2 => 4
+```
+```jldoctest
+julia> using Graphs
+
+julia> g = static_fitness_model(5, [1, 1, 0.5, 0.1], seed=123)
+{4, 5} undirected simple Int64 graph
+
+julia> edges(g) |> collect
+5-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
+ Edge 1 => 2
+ Edge 1 => 3
+ Edge 2 => 3
+ Edge 2 => 4
+ Edge 3 => 4
 ```
 """
 function static_fitness_model(
@@ -715,11 +756,13 @@ Time complexity is ``\\mathcal{O}(|V| + |E| log |E|)``.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = static_fitness_model(6, [1, 0.2, 0.2, 0.2], [0.1, 0.1, 0.1, 0.9]; seed=123)
 {4, 6} directed simple Int64 graph
 
 julia> edges(g) |> collect
-6-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+6-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 3
  Edge 1 => 4
@@ -977,6 +1020,8 @@ Generates a random labelled tree, drawn uniformly at random over the ``n^{n-2}``
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> uniform_tree(10)
 {10, 9} undirected simple Int64 graph
 ```
@@ -1050,6 +1095,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> random_tournament_digraph(5)
 {5, 10} directed simple Int64 graph
 
@@ -1423,6 +1470,8 @@ the `t`th stage of this algorithm by accessing the first `t` vertices with `g[1:
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> dorogovtsev_mendes(10)
 {10, 17} undirected simple Int64 graph
 
@@ -1472,10 +1521,12 @@ DAG's have a finite topological order; this order is randomly generated via "ord
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> random_orientation_dag(complete_graph(10))
 {10, 45} directed simple Int64 graph
 
-julia> random_orientation_dag(star_graph(Int8(10)), 123)
+julia> random_orientation_dag(star_graph(Int8(10)), seed=123)
 {10, 9} directed simple Int8 graph
 ```
 """

--- a/src/SimpleGraphs/generators/staticgraphs.jl
+++ b/src/SimpleGraphs/generators/staticgraphs.jl
@@ -9,6 +9,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> complete_graph(5)
 {5, 10} undirected simple Int64 graph
 
@@ -37,6 +39,8 @@ with `n1 + n2` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> complete_bipartite_graph(3, 4)
 {7, 12} undirected simple Int64 graph
 
@@ -76,6 +80,8 @@ exceeds the eltype.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> complete_multipartite_graph([1,2,3])
 {6, 11} undirected simple Int64 graph
 
@@ -121,6 +127,8 @@ multipartite graph with `n` vertices and `r` partitions.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> turan_graph(6, 2)
 {6, 9} undirected simple Int64 graph
 
@@ -152,6 +160,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> complete_digraph(5)
 {5, 20} directed simple Int64 graph
 
@@ -183,6 +193,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> star_graph(3)
 {3, 2} undirected simple Int64 graph
 
@@ -210,6 +222,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> star_digraph(3)
 {3, 2} directed simple Int64 graph
 
@@ -240,6 +254,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> path_graph(5)
 {5, 4} undirected simple Int64 graph
 
@@ -269,6 +285,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> path_digraph(5)
 {5, 4} directed simple Int64 graph
 
@@ -303,6 +321,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> cycle_graph(3)
 {3, 3} undirected simple Int64 graph
 
@@ -333,6 +353,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> cycle_digraph(3)
 {3, 3} directed simple Int64 graph
 
@@ -367,6 +389,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> wheel_graph(5)
 {5, 8} undirected simple Int64 graph
 
@@ -398,6 +422,8 @@ with `n` vertices.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> wheel_digraph(5)
 {5, 8} directed simple Int64 graph
 
@@ -438,6 +464,8 @@ condition in each dimension.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> grid([2,3])
 {6, 7} undirected simple Int64 graph
 
@@ -481,6 +509,8 @@ of depth `k`.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> binary_tree(4)
 {15, 14} undirected simple Int64 graph
 
@@ -521,6 +551,8 @@ Create a double complete binary tree with `k` levels.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> double_binary_tree(4)
 {30, 29} undirected simple Int64 graph
 
@@ -546,6 +578,8 @@ Create a Roach graph of size `k`.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> roach_graph(10)
 {40, 48} undirected simple Int64 graph
 ```
@@ -568,6 +602,8 @@ Create a graph consisting of `n` connected `k`-cliques.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> clique_graph(4, 10)
 {40, 70} undirected simple Int64 graph
 
@@ -604,6 +640,8 @@ exceeds the eltype.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> ladder_graph(3)
 {6, 7} undirected simple Int64 graph
 
@@ -643,6 +681,8 @@ exceeds the eltype.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> circular_ladder_graph(3)
 {6, 9} undirected simple Int64 graph
 
@@ -671,6 +711,8 @@ The cliques are organized with nodes `1:n1` being the left clique and `n1+1:n1+n
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> barbell_graph(3, 4)
 {7, 10} undirected simple Int64 graph
 
@@ -718,6 +760,8 @@ The graph is organized with nodes `1:n1` being the clique and `n1+1:n1+n2` being
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> lollipop_graph(2, 5)
 {7, 6} undirected simple Int64 graph
 

--- a/src/SimpleGraphs/simpledigraph.jl
+++ b/src/SimpleGraphs/simpledigraph.jl
@@ -35,6 +35,8 @@ If not specified, the element type `T` is the type of `n`.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> SimpleDiGraph(UInt8(10))
 {10, 0} directed simple UInt8 graph
 ```
@@ -59,6 +61,8 @@ Construct an empty `SimpleDiGraph{T}` with 0 vertices and 0 edges.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> SimpleDiGraph(UInt8)
 {0, 0} directed simple UInt8 graph
 ```
@@ -75,11 +79,21 @@ The element type `T` can be omitted.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> A1 = [false true; false false]
+2×2 Matrix{Bool}:
+ 0  1
+ 0  0
+
 julia> SimpleDiGraph(A1)
 {2, 1} directed simple Int64 graph
 
 julia> A2 = [2 7; 5 0]
+2×2 Matrix{Int64}:
+ 2  7
+ 5  0
+
 julia> SimpleDiGraph{Int16}(A2)
 {2, 3} directed simple Int16 graph
 ```
@@ -129,7 +143,11 @@ Otherwise the element type is the same as for `g`.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = complete_digraph(5)
+{5, 20} directed simple Int64 graph
+
 julia> SimpleDiGraph{UInt8}(g)
 {5, 20} directed simple UInt8 graph
 ```
@@ -151,7 +169,11 @@ The element type is the same as for `g`.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = path_graph(Int8(5))
+{5, 4} undirected simple Int8 graph
+
 julia> SimpleDiGraph(g)
 {5, 8} directed simple Int8 graph
 ```
@@ -198,8 +220,14 @@ by the lexical ordering and does not contain any duplicates.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
 
 julia> el = Edge.([ (1, 3), (1, 5), (3, 1) ])
+3-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
+ Edge 1 => 3
+ Edge 1 => 5
+ Edge 3 => 1
+ 
 julia> SimpleDiGraph(el)
 {5, 3} directed simple Int64 graph
 ```
@@ -349,7 +377,7 @@ julia> h = SimpleDiGraphFromIterator(edges(g))
 {2, 2} directed simple Int64 graph
 
 julia> collect(edges(h))
-2-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+2-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 2 => 1
 ```

--- a/src/SimpleGraphs/simpleedgeiter.jl
+++ b/src/SimpleGraphs/simpleedgeiter.jl
@@ -15,10 +15,10 @@ julia> es = edges(g)
 SimpleEdgeIter 2
 
 julia> e_it = iterate(es)
-(Edge 1 => 2, SimpleEdgeIterState [2, 2])
+(Edge 1 => 2, (1, 2))
 
 julia> iterate(es, e_it[2])
-(Edge 2 => 3, SimpleEdgeIterState [0, 1])
+(Edge 2 => 3, (2, 3))
 ```
 """
 struct SimpleEdgeIter{G} <: AbstractEdgeIter

--- a/src/SimpleGraphs/simplegraph.jl
+++ b/src/SimpleGraphs/simplegraph.jl
@@ -30,6 +30,8 @@ If not specified, the element type `T` is the type of `n`.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> SimpleGraph(UInt8(10))
 {10, 0} undirected simple UInt8 graph
 ```
@@ -53,6 +55,8 @@ Construct an empty `SimpleGraph{T}` with 0 vertices and 0 edges.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> SimpleGraph(UInt8)
 {0, 0} undirected simple UInt8 graph
 ```
@@ -69,11 +73,15 @@ The element type `T` can be omitted.
 
 ## Examples
 ```jldoctest
-julia> A1 = [false true; true false]
+julia> using Graphs
+
+julia> A1 = [false true; true false];
+
 julia> SimpleGraph(A1)
 {2, 1} undirected simple Int64 graph
 
-julia> A2 = [2 7; 7 0]
+julia> A2 = [2 7; 7 0];
+
 julia> SimpleGraph{Int16}(A2)
 {2, 2} undirected simple Int16 graph
 ```
@@ -105,7 +113,11 @@ Otherwise the element type is the same as for `g`.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = complete_graph(5)
+{5, 10} undirected simple Int64 graph
+
 julia> SimpleGraph{UInt8}(g)
 {5, 10} undirected simple UInt8 graph
 ```
@@ -128,7 +140,11 @@ The element type is the same as for `g`.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = path_digraph(Int8(5))
+{5, 4} directed simple Int8 graph
+
 julia> SimpleGraph(g)
 {5, 4} undirected simple Int8 graph
 ```
@@ -191,8 +207,13 @@ by the lexical ordering and does not contain any duplicates.
 
 ## Examples
 ```jldoctest
+julia> using Graphs
 
 julia> el = Edge.([ (1, 2), (1, 5) ])
+2-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
+ Edge 1 => 2
+ Edge 1 => 5
+
 julia> SimpleGraph(el)
 {5, 2} undirected simple Int64 graph
 ```
@@ -337,7 +358,7 @@ julia> add_edge!(g, 2, 3);
 julia> h = SimpleGraphFromIterator(edges(g));
 
 julia> collect(edges(h))
-2-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+2-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 2 => 3
 ```
@@ -538,13 +559,13 @@ This function is not part of the official Graphs API and is subject to change/re
 ```jldoctest
 julia> using Graphs
 
-julia> g = complete_graph{5}
+julia> g = complete_graph(5)
 {5, 10} undirected simple Int64 graph
 
 julia> vmap = rem_vertices!(g, [2, 4], keep_order=true);
 
 julia> vmap
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  1
  3
  5

--- a/src/biconnectivity/articulation.jl
+++ b/src/biconnectivity/articulation.jl
@@ -9,11 +9,11 @@ of a connected graph `g` and return an array containing all cut vertices.
 julia> using Graphs
 
 julia> articulation(star_graph(5))
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  1
 
 julia> articulation(path_graph(5))
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  2
  3
  4

--- a/src/biconnectivity/biconnect.jl
+++ b/src/biconnectivity/biconnect.jl
@@ -74,14 +74,14 @@ Time complexity is ``\\mathcal{O}(|V|)``.
 julia> using Graphs
 
 julia> biconnected_components(star_graph(5))
-4-element Array{Array{Graphs.SimpleGraphs.SimpleEdge,1},1}:
+4-element Vector{Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}}:
  [Edge 1 => 3]
  [Edge 1 => 4]
  [Edge 1 => 5]
  [Edge 1 => 2]
 
 julia> biconnected_components(cycle_graph(5))
-1-element Array{Array{Graphs.SimpleGraphs.SimpleEdge,1},1}:
+1-element Vector{Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}}:
  [Edge 1 => 5, Edge 4 => 5, Edge 3 => 4, Edge 2 => 3, Edge 1 => 2]
 ```
 """

--- a/src/biconnectivity/bridge.jl
+++ b/src/biconnectivity/bridge.jl
@@ -9,14 +9,14 @@ whose deletion increases the number of connected components of the graph.
 julia> using Graphs
 
 julia> bridges(star_graph(5))
-8-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+4-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 3
  Edge 1 => 4
  Edge 1 => 5
 
 julia> bridges(path_graph(5))
-8-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+4-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 4 => 5
  Edge 3 => 4
  Edge 2 => 3

--- a/src/centrality/betweenness.jl
+++ b/src/centrality/betweenness.jl
@@ -29,13 +29,13 @@ bc(v) = \\frac{1}{\\mathcal{N}} \\sum_{s \\neq t \\neq v}
 julia> using Graphs
 
 julia> betweenness_centrality(star_graph(3))
-3-element Array{Float64,1}:
+3-element Vector{Float64}:
  1.0
  0.0
  0.0
 
 julia> betweenness_centrality(path_graph(4))
-4-element Array{Float64,1}:
+4-element Vector{Float64}:
  0.0
  0.6666666666666666
  0.6666666666666666

--- a/src/centrality/closeness.jl
+++ b/src/centrality/closeness.jl
@@ -14,7 +14,7 @@ from node `n`.
 julia> using Graphs
 
 julia> closeness_centrality(star_graph(5))
-5-element Array{Float64,1}:
+5-element Vector{Float64}:
  1.0
  0.5714285714285714
  0.5714285714285714
@@ -22,7 +22,7 @@ julia> closeness_centrality(star_graph(5))
  0.5714285714285714
 
 julia> closeness_centrality(path_graph(4))
-4-element Array{Float64,1}:
+4-element Vector{Float64}:
  0.5
  0.75
  0.75

--- a/src/centrality/degree.jl
+++ b/src/centrality/degree.jl
@@ -31,14 +31,14 @@ of graph `g`. Return a vector representing the centrality calculated for each no
 julia> using Graphs
 
 julia> degree_centrality(star_graph(4))
-4-element Array{Float64,1}:
+4-element Vector{Float64}:
  1.0               
  0.3333333333333333
  0.3333333333333333
  0.3333333333333333
 
 julia> degree_centrality(path_graph(3))
-3-element Array{Float64,1}:
+3-element Vector{Float64}:
  0.5
  1.0
  0.5

--- a/src/centrality/radiality.jl
+++ b/src/centrality/radiality.jl
@@ -21,14 +21,14 @@ length of the shortest path from ``u`` to ``v``.
 julia> using Graphs
 
 julia> radiality_centrality(star_graph(4))
-4-element Array{Float64,1}:
+4-element Vector{Float64}:
  1.0               
  0.6666666666666666
  0.6666666666666666
  0.6666666666666666
 
 julia> radiality_centrality(path_graph(3))
-3-element Array{Float64,1}:
+3-element Vector{Float64}:
  0.75
  1.0 
  0.75

--- a/src/centrality/stress.jl
+++ b/src/centrality/stress.jl
@@ -17,13 +17,13 @@ The stress centrality of a vertex ``n`` is defined as the number of shortest pat
 julia> using Graphs
 
 julia> stress_centrality(star_graph(3))
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  2
  0
  0
 
 julia> stress_centrality(cycle_graph(4))
-4-element Array{Int64,1}:
+4-element Vector{Int64}:
  2
  2
  2

--- a/src/community/clique_percolation.jl
+++ b/src/community/clique_percolation.jl
@@ -13,16 +13,16 @@ The parameter `k` defines the size of the clique to use in percolation.
 julia> using Graphs
 
 julia> clique_percolation(clique_graph(3, 2))
-2-element Array{BitSet,1}:
+2-element Vector{BitSet}:
  BitSet([4, 5, 6])
  BitSet([1, 2, 3])
 
 julia> clique_percolation(clique_graph(3, 2), k=2)
-1-element Array{BitSet,1}:
+1-element Vector{BitSet}:
  BitSet([1, 2, 3, 4, 5, 6])
 
 julia> clique_percolation(clique_graph(3, 2), k=4)
-0-element Array{BitSet,1}
+BitSet[]
 ```
 """
 function clique_percolation end

--- a/src/community/cliques.jl
+++ b/src/community/cliques.jl
@@ -13,13 +13,20 @@ cliques found in the undirected graph `g`.
 
 ```jldoctest
 julia> using Graphs
+
 julia> g = SimpleGraph(3)
+{3, 0} undirected simple Int64 graph
+
 julia> add_edge!(g, 1, 2)
+true
+
 julia> add_edge!(g, 2, 3)
+true
+
 julia> maximal_cliques(g)
-2-element Array{Array{Int64,N},1}:
- [2,3]
- [2,1]
+2-element Vector{Vector{Int64}}:
+ [2, 3]
+ [2, 1]
 ```
 """
 function maximal_cliques end

--- a/src/community/clustering.jl
+++ b/src/community/clustering.jl
@@ -19,7 +19,7 @@ julia> add_edge!(g, 2, 4);
 julia> add_edge!(g, 4, 1);
 
 julia> local_clustering_coefficient(g, [1, 2, 3])
-3-element Array{Float64,1}:
+3-element Vector{Float64}:
  1.0
  1.0
  0.0
@@ -113,7 +113,7 @@ julia> add_edge!(g, 2, 4);
 julia> add_edge!(g, 4, 1);
 
 julia> triangles(g)
-4-element Array{Int64,1}:
+4-element Vector{Int64}:
  1
  1
  0

--- a/src/community/core-periphery.jl
+++ b/src/community/core-periphery.jl
@@ -12,7 +12,7 @@ References:
 julia> using Graphs
 
 julia> core_periphery_deg(star_graph(5))
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  2
  2
@@ -20,7 +20,7 @@ julia> core_periphery_deg(star_graph(5))
  2
 
 julia> core_periphery_deg(path_graph(3))
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  2
  1
  2

--- a/src/community/modularity.jl
+++ b/src/community/modularity.jl
@@ -52,7 +52,8 @@ julia> modularity(barbell, [1, 1, 1, 2, 2, 2])
 
 julia> modularity(barbell, [1, 1, 1, 2, 2, 2], γ=0.5)
 0.6071428571428571  
-
+```
+```
 julia> using SimpleWeightedGraphs
 
 julia> triangle = SimpleWeightedGraph(3);

--- a/src/community/rich_club.jl
+++ b/src/community/rich_club.jl
@@ -6,7 +6,10 @@ with degree cut-off `k`.
 
 ```jldoctest
 julia> using Graphs
+
 julia> g = star_graph(5)
+{5, 4} undirected simple Int64 graph
+
 julia> rich_club(g, 1)
 0.4
 ```

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -80,16 +80,18 @@ For directed graphs, see [`strongly_connected_components`](@ref) and
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleGraph([0 1 0; 1 0 1; 0 1 0]);
 
 julia> connected_components(g)
-1-element Array{Array{Int64,1},1}:
+1-element Vector{Vector{Int64}}:
  [1, 2, 3]
 
 julia> g = SimpleGraph([0 1 0 0 0; 1 0 1 0 0; 0 1 0 0 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> connected_components(g)
-2-element Array{Array{Int64,1},1}:
+2-element Vector{Vector{Int64}}:
  [1, 2, 3]
  [4, 5]
 ```
@@ -109,6 +111,8 @@ if graph `g` is weakly connected.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleGraph([0 1 0; 1 0 1; 0 1 0]);
 
 julia> is_connected(g)
@@ -139,10 +143,12 @@ For undirected graphs this is equivalent to the [`connected_components`](@ref) o
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0; 1 0 1; 0 0 0]);
 
 julia> weakly_connected_components(g)
-1-element Array{Array{Int64,1},1}:
+1-element Vector{Vector{Int64}}:
  [1, 2, 3]
 ```
 """
@@ -156,6 +162,8 @@ this function is equivalent to [`is_connected(g)`](@ref).
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0; 0 0 1; 1 0 0]);
 
 julia> is_weakly_connected(g)
@@ -187,15 +195,16 @@ The order of the components is not part of the API contract.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0; 1 0 1; 0 0 0]);
 
 julia> strongly_connected_components(g)
-2-element Array{Array{Int64,1},1}:
+2-element Vector{Vector{Int64}}:
  [3]
  [1, 2]
 
-
-julia> g=SimpleDiGraph(11)
+julia> g = SimpleDiGraph(11)
 {11, 0} directed simple Int64 graph
 
 julia> edge_list=[(1,2),(2,3),(3,4),(4,1),(3,5),(5,6),(6,7),(7,5),(5,8),(8,9),(9,8),(10,11),(11,10)];
@@ -204,12 +213,11 @@ julia> g = SimpleDiGraph(Edge.(edge_list))
 {11, 13} directed simple Int64 graph
 
 julia> strongly_connected_components(g)
-4-element Array{Array{Int64,1},1}:
+4-element Vector{Vector{Int64}}:
  [8, 9]
  [5, 6, 7]
  [1, 2, 3, 4]
  [10, 11]
-
 ```
 """
 function strongly_connected_components end
@@ -325,6 +333,7 @@ Space Complexity : O(|V|) {Excluding the memory required for storing graph}
 
 ### Examples
 ```jldoctest
+julia> using Graphs
 
 julia> g=SimpleDiGraph(3)
 {3, 0} directed simple Int64 graph
@@ -333,7 +342,7 @@ julia> g = SimpleDiGraph([0 1 0 ; 0 0 1; 0 0 0])
 {3, 2} directed simple Int64 graph
 
 julia> strongly_connected_components_kosaraju(g)
-3-element Array{Array{Int64,1},1}:
+3-element Vector{Vector{Int64}}:
  [1]
  [2]
  [3]
@@ -343,7 +352,7 @@ julia> g=SimpleDiGraph(11)
 {11, 0} directed simple Int64 graph
 
 julia> edge_list=[(1,2),(2,3),(3,4),(4,1),(3,5),(5,6),(6,7),(7,5),(5,8),(8,9),(9,8),(10,11),(11,10)]
-13-element Array{Tuple{Int64,Int64},1}:
+13-element Vector{Tuple{Int64, Int64}}:
  (1, 2)
  (2, 3)
  (3, 4)
@@ -362,7 +371,7 @@ julia> g = SimpleDiGraph(Edge.(edge_list))
 {11, 13} directed simple Int64 graph
 
 julia> strongly_connected_components_kosaraju(g)
-4-element Array{Array{Int64,1},1}:
+4-element Vector{Vector{Int64}}:
  [11, 10]
  [2, 3, 4, 1]
  [6, 7, 5]
@@ -464,6 +473,8 @@ Return `true` if directed graph `g` is strongly connected.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0; 0 0 1; 1 0 0]);
 
 julia> is_strongly_connected(g)
@@ -483,6 +494,8 @@ Will throw an error if the graph is not strongly connected.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0; 0 0 1; 1 0 0]);
 
 julia> period(g)
@@ -521,11 +534,13 @@ connected components first.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0])
 {5, 6} directed simple Int64 graph
 
 julia> strongly_connected_components(g)
-2-element Array{Array{Int64,1},1}:
+2-element Vector{Vector{Int64}}:
  [4, 5]
  [1, 2, 3]
 
@@ -564,16 +579,18 @@ connected components in which the components do not have any leaving edges.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0])
 {5, 6} directed simple Int64 graph
 
 julia> strongly_connected_components(g)
-2-element Array{Array{Int64,1},1}:
+2-element Vector{Vector{Int64}}:
  [4, 5]
  [1, 2, 3]
 
 julia> attracting_components(g)
-1-element Array{Array{Int64,1},1}:
+1-element Vector{Vector{Int64}}:
  [4, 5]
 ```
 """
@@ -605,23 +622,25 @@ with respect to `v` of the edges to be considered. Possible values: `:in` or `:o
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> neighborhood(g, 1, 2)
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  1
  2
  3
 
 julia> neighborhood(g, 1, 3)
-4-element Array{Int64,1}:
+4-element Vector{Int64}:
  1
  2
  3
  4
 
 julia> neighborhood(g, 1, 3, [0 1 0 0 0; 0 0 1 0 0; 1 0 0 0.25 0; 0 0 0 0 0.25; 0 0 0 0.25 0])
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  2
  3
@@ -647,17 +666,19 @@ with respect to `v` of the edges to be considered. Possible values: `:in` or `:o
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> neighborhood_dists(g, 1, 3)
-4-element Array{Tuple{Int64,Int64},1}:
+4-element Vector{Tuple{Int64, Int64}}:
  (1, 0)
  (2, 1)
  (3, 2)
  (4, 3)
 
 julia> neighborhood_dists(g, 1, 3, [0 1 0 0 0; 0 0 1 0 0; 1 0 0 0.25 0; 0 0 0 0 0.25; 0 0 0 0.25 0])
-5-element Array{Tuple{Int64,Float64},1}:
+5-element Vector{Tuple{Int64, Float64}}:
  (1, 0.0)
  (2, 1.0)
  (3, 2.0)
@@ -665,12 +686,12 @@ julia> neighborhood_dists(g, 1, 3, [0 1 0 0 0; 0 0 1 0 0; 1 0 0 0.25 0; 0 0 0 0 
  (5, 2.5)
 
 julia> neighborhood_dists(g, 4, 3)
-2-element Array{Tuple{Int64,Int64},1}:
+2-element Vector{Tuple{Int64, Int64}}:
  (4, 0)
  (5, 1)
 
 julia> neighborhood_dists(g, 4, 3, dir=:in)
-5-element Array{Tuple{Int64,Int64},1}:
+5-element Vector{Tuple{Int64, Int64}}:
  (4, 0)
  (3, 1)
  (5, 1)

--- a/src/core.jl
+++ b/src/core.jl
@@ -61,7 +61,7 @@ julia> add_edge!(g, 2, 3);
 julia> add_edge!(g, 3, 1);
 
 julia> indegree(g)
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  1
  0
  1
@@ -87,7 +87,7 @@ julia> add_edge!(g, 2, 3);
 julia> add_edge!(g, 3, 1);
 
 julia> outdegree(g)
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  0
  1
  1
@@ -115,7 +115,7 @@ julia> add_edge!(g, 2, 3);
 julia> add_edge!(g, 3, 1);
 
 julia> degree(g)
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  1
  1
  2
@@ -226,14 +226,14 @@ julia> add_edge!(g, 2, 3);
 julia> add_edge!(g, 3, 1);
 
 julia> neighbors(g, 1)
-0-element Array{Int64,1}
+Int64[]
 
 julia> neighbors(g, 2)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  3
 
 julia> neighbors(g, 3)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  1
 ```
 """
@@ -262,15 +262,15 @@ julia> add_edge!(g, 2, 3);
 julia> add_edge!(g, 3, 1);
 
 julia> all_neighbors(g, 1)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  3
 
 julia> all_neighbors(g, 2)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  3
 
 julia> all_neighbors(g, 3)
-2-element Array{Int64,1}:
+2-element Vector{Int64}:
  1
  2
 ```
@@ -308,12 +308,12 @@ julia> add_edge!(g, 4, 1);
 julia> add_edge!(g, 1, 3);
 
 julia> common_neighbors(g, 1, 3)
-2-element Array{Int64,1}:
+2-element Vector{Int64}:
  2
  4
 
 julia> common_neighbors(g, 1, 4)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  3
 ```
 """

--- a/src/cycles/basis.jl
+++ b/src/cycles/basis.jl
@@ -14,14 +14,16 @@ using Kirchhoff's Laws.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> elist = [(1,2),(2,3),(2,4),(3,4),(4,1),(1,5)];
 
-julia> g = SimpleGraph(SimpleEdge.(elist));
+julia> g = SimpleGraph(Graphs.SimpleEdge.(elist));
 
 julia> cycle_basis(g)
-2-element Array{Array{Int64,1},1}:
+2-element Vector{Vector{Int64}}:
+ [2, 4, 1]
  [2, 3, 4]
- [2, 1, 3]
 ```
 
 ### References

--- a/src/cycles/incremental.jl
+++ b/src/cycles/incremental.jl
@@ -46,10 +46,13 @@ common source or target more efficiently than individual updates.
 ## Example
 
 ```jldoctest
+julia> using Graphs
+
 julia> G = SimpleDiGraph(3)
+{3, 0} directed simple Int64 graph
 
 julia> ict = IncrementalCycleTracker(G)
-BFGT_N cycle tracker on {3, 0} directed simple Int64 graph
+BFGT_N cycle tracker on SimpleDiGraph{Int64}(0, [Int64[], Int64[], Int64[]], [Int64[], Int64[], Int64[]])
 
 julia> add_edge_checked!(ict, 1, 2)
 true
@@ -71,8 +74,8 @@ false
 
 julia> collect(edges(G))
 2-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
-Edge 1 => 2
-Edge 2 => 3
+ Edge 1 => 2
+ Edge 2 => 3
 ```
 """
 function add_edge_checked! end

--- a/src/cycles/johnson.jl
+++ b/src/cycles/johnson.jl
@@ -179,8 +179,10 @@ short cycles of a limited length, [`simplecycles_limited_length`](@ref) can be m
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> simplecycles(complete_digraph(3))
-5-element Array{Array{Int64,1},1}:
+5-element Vector{Vector{Int64}}:
  [1, 2]
  [1, 2, 3]
  [1, 3]
@@ -308,6 +310,8 @@ theoretical maximum number or cycles.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> simplecyclescount(complete_digraph(6))
 409
 ```
@@ -370,6 +374,8 @@ a subset of the cycles lengths.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> simplecycleslength(complete_digraph(16))
 ([0, 1, 1, 1, 1, 1, 2, 10, 73, 511, 3066, 15329, 61313, 183939, 367876, 367876], 1000000)
 

--- a/src/degeneracy.jl
+++ b/src/degeneracy.jl
@@ -26,7 +26,7 @@ julia> add_vertex!(g);
 julia> add_edge!(g, 5, 2);
 
 julia> core_number(g)
-6-element Array{Int64,1}:
+6-element Vector{Int64}:
  1
  2
  2
@@ -138,7 +138,7 @@ julia> add_vertex!(g);
 julia> add_edge!(g, 5, 2);
 
 julia> k_core(g, 1)
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  2
  3
@@ -146,7 +146,7 @@ julia> k_core(g, 1)
  5
 
 julia> k_core(g, 2)
-4-element Array{Int64,1}:
+4-element Vector{Int64}:
  2
  3
  4
@@ -194,15 +194,15 @@ julia> add_vertex!(g);
 julia> add_edge!(g, 5, 2);
 
 julia> k_shell(g, 0)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  6
 
 julia> k_shell(g, 1)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  1
 
 julia> k_shell(g, 2)
-4-element Array{Int64,1}:
+4-element Vector{Int64}:
  2
  3
  4
@@ -249,16 +249,16 @@ julia> add_vertex!(g);
 julia> add_edge!(g, 5, 2);
 
 julia> k_crust(g, 0)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  6
 
 julia> k_crust(g, 1)
-2-element Array{Int64,1}:
+2-element Vector{Int64}:
  1
  6
 
 julia> k_crust(g, 2)
-6-element Array{Int64,1}:
+6-element Vector{Int64}:
  1
  2
  3
@@ -305,22 +305,22 @@ julia> add_vertex!(g);
 julia> add_edge!(g, 5, 2);
 
 julia> k_corona(g, 0)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  6
 
 julia> k_corona(g, 1)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  1
 
 julia> k_corona(g, 2)
-4-element Array{Int64,1}:
+4-element Vector{Int64}:
  2
  3
  4
  5
 
 julia> k_corona(g, 3)
-0-element Array{Int64,1}
+Int64[]
 ```
 """
 function k_corona(g::AbstractGraph, k; corenum=core_number(g))

--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -54,7 +54,7 @@ is `true`, add self loops to the graph.
 Time complexity is ``\\mathcal{O}(|E||V|)``.
 
 # Examples
-```jldoctest
+```
 julia> using Graphs
 
 julia> barbell = blockdiag(complete_digraph(3), complete_digraph(3));
@@ -62,7 +62,7 @@ julia> barbell = blockdiag(complete_digraph(3), complete_digraph(3));
 julia> add_edge!(barbell, 1, 4);
 
 julia> collect(edges(barbell))
-13-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+13-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 3
  Edge 1 => 4
@@ -78,7 +78,7 @@ julia> collect(edges(barbell))
  Edge 6 => 5
 
 julia> collect(edges(transitiveclosure(barbell)))
-21-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+21-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 3
  Edge 1 => 4
@@ -128,7 +128,7 @@ julia> barbell = blockdiag(complete_digraph(3), complete_digraph(3));
 julia> add_edge!(barbell, 1, 4);
 
 julia> collect(edges(barbell))
-13-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+13-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 3
  Edge 1 => 4
@@ -144,7 +144,7 @@ julia> collect(edges(barbell))
  Edge 6 => 5
 
 julia> collect(edges(transitivereduction(barbell)))
-7-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+7-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 4
  Edge 2 => 3

--- a/src/distance.jl
+++ b/src/distance.jl
@@ -53,18 +53,20 @@ An infinite path length is represented by the `typemax` of the distance matrix.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleGraph([0 1 0; 1 0 1; 0 1 0]);
 
 julia> eccentricity(g, 1)
 2
 
 julia> eccentricity(g, [1; 2])
-2-element Array{Int64,1}:
+2-element Vector{Int64}:
  2
  1
 
 julia> eccentricity(g, [1; 2], [0 2 0; 0.5 0 0.5; 0 2 0])
-2-element Array{Float64,1}:
+2-element Vector{Float64}:
  2.5
  0.5
 ```
@@ -123,14 +125,14 @@ largest eccentricity).
 julia> using Graphs
 
 julia> periphery(star_graph(5))
-4-element Array{Int64,1}:
+4-element Vector{Int64}:
  2
  3
  4
  5
 
 julia> periphery(path_graph(5))
-2-element Array{Int64,1}:
+2-element Vector{Int64}:
  1
  5
 ```
@@ -180,11 +182,11 @@ to the graph's radius (that is, the set of vertices with the smallest eccentrici
 julia> using Graphs
 
 julia> center(star_graph(5))
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  1
 
 julia> center(path_graph(5))
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  3
 ```
 """

--- a/src/editdist.jl
+++ b/src/editdist.jl
@@ -42,6 +42,8 @@ if involved costs are equivalent.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g1 = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> g2 = SimpleDiGraph([0 1 0; 0 0 1; 1 0 0]);

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -170,7 +170,7 @@ is invalidated by changes to `g`.
 julia> using Graphs
 
 julia> collect(vertices(SimpleGraph(4)))
-4-element Array{Int64,1}:
+4-element Vector{Int64}:
  1
  2
  3
@@ -198,7 +198,7 @@ julia> using Graphs
 julia> g = path_graph(3);
 
 julia> collect(edges(g))
-2-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+2-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 2 => 3
 ```
@@ -287,10 +287,12 @@ the array behind this reference may be modified too, but this is not guaranteed.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> inneighbors(g, 4)
-2-element Array{Int64,1}:
+2-element Vector{Int64}:
  3
  5
 ```
@@ -309,10 +311,12 @@ the array behind this reference may be modified too, but this is not guaranteed.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> outneighbors(g, 4)
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  5
 ```
 """
@@ -326,6 +330,8 @@ The fallback is defined for graph values `zero(g::G) = zero(G)`.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> zero(typeof(g))

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -9,6 +9,8 @@ Preserves the `eltype` of the input graph.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> foreach(println, edges(complement(g)))
@@ -63,6 +65,8 @@ Preserves the eltype of the input graph.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> foreach(println, edges(reverse(g)))
@@ -109,6 +113,8 @@ number of vertices in the generated graph exceeds the `eltype`.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g1 = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> g2 = SimpleDiGraph([0 1 0; 0 0 1; 1 0 0]);
@@ -151,6 +157,8 @@ Preserves the eltype of the input graph.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g1 = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> g2 = SimpleDiGraph([0 1 0; 0 0 1; 1 0 0]);
@@ -183,6 +191,8 @@ Preserves the `eltype` of the input graph.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g1 = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> g2 = SimpleDiGraph([0 1 0; 0 0 1; 1 0 0]);
@@ -230,7 +240,7 @@ julia> add_edge!(h, 2, 3);
 julia> f = symmetric_difference(g, h);
 
 julia> collect(edges(f))
-3-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+3-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 3
  Edge 2 => 3
@@ -279,7 +289,7 @@ julia> add_edge!(h, 4, 5);
 julia> f = union(g, h);
 
 julia> collect(edges(f))
-5-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+5-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 3
  Edge 3 => 4
@@ -323,7 +333,7 @@ julia> g = join(star_graph(3), path_graph(2))
 {5, 9} undirected simple Int64 graph
 
 julia> collect(edges(g))
-9-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+9-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 3
  Edge 1 => 4
@@ -363,7 +373,7 @@ julia> g = crosspath(3, path_graph(3))
 {9, 12} undirected simple Int64 graph
 
 julia> collect(edges(g))
-12-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+12-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 4
  Edge 2 => 3
@@ -422,10 +432,12 @@ Return a vector of indegree (`i`=1) or outdegree (`i`=2) values for graph `g`.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
 
 julia> sum(g, 2)
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  1
  2
@@ -433,7 +445,7 @@ julia> sum(g, 2)
  1
 
 julia> sum(g, 1)
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  1
  1
@@ -478,6 +490,8 @@ Return the number of edges in `g`.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g = SimpleGraph([0 1 0; 1 0 1; 0 1 0]);
 
 julia> sum(g)
@@ -515,7 +529,7 @@ julia> g = cartesian_product(star_graph(3), path_graph(3))
 {9, 12} undirected simple Int64 graph
 
 julia> collect(edges(g))
-12-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+12-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 1 => 4
  Edge 1 => 7
@@ -567,7 +581,7 @@ julia> g = tensor_product(star_graph(3), path_graph(3))
 {9, 8} undirected simple Int64 graph
 
 julia> collect(edges(g))
-8-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+8-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 5
  Edge 1 => 8
  Edge 2 => 4
@@ -737,7 +751,7 @@ julia> using Graphs
 julia> g = path_graph(5);
 
 julia> collect(edges(g))
-4-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+4-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 2 => 3
  Edge 3 => 4
@@ -746,7 +760,7 @@ julia> collect(edges(g))
 julia> h = merge_vertices(g, [2, 3]);
 
 julia> collect(edges(h))
-3-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+3-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 2 => 3
  Edge 3 => 4
@@ -797,14 +811,14 @@ julia> using Graphs
 julia> g = path_graph(5);
 
 julia> collect(edges(g))
-4-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+4-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 2 => 3
  Edge 3 => 4
  Edge 4 => 5
 
 julia> merge_vertices!(g, [2, 3])
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  2
  2
@@ -812,7 +826,7 @@ julia> merge_vertices!(g, [2, 3])
  4
 
 julia> collect(edges(g))
-3-element Array{Graphs.SimpleGraphs.SimpleEdge{Int64},1}:
+3-element Vector{Graphs.SimpleGraphs.SimpleEdge{Int64}}:
  Edge 1 => 2
  Edge 2 => 3
  Edge 3 => 4

--- a/src/persistence/common.jl
+++ b/src/persistence/common.jl
@@ -114,6 +114,8 @@ Return the number of graphs written.
 
 # Examples
 ```jldoctest
+julia> using Graphs
+
 julia> g1 = SimpleGraph(5,8)
 {5, 8} undirected simple Int64 graph
 

--- a/src/shortestpaths/desopo-pape.jl
+++ b/src/shortestpaths/desopo-pape.jl
@@ -22,7 +22,7 @@ julia> using Graphs
 julia> ds = desopo_pape_shortest_paths(cycle_graph(5), 2);
 
 julia> ds.dists
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  0
  1
@@ -32,7 +32,7 @@ julia> ds.dists
 julia> ds = desopo_pape_shortest_paths(path_graph(5), 2);
 
 julia> ds.dists
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  0
  1

--- a/src/shortestpaths/dijkstra.jl
+++ b/src/shortestpaths/dijkstra.jl
@@ -49,7 +49,7 @@ julia> using Graphs
 julia> ds = dijkstra_shortest_paths(cycle_graph(5), 2);
 
 julia> ds.dists
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  0
  1
@@ -59,7 +59,7 @@ julia> ds.dists
 julia> ds = dijkstra_shortest_paths(path_graph(5), 2);
 
 julia> ds.dists
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  0
  1

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -18,6 +18,22 @@ other nodes in graph `g` using the [Shortest Path Faster Algorithm]
 # Examples
 
 ```jldoctest
+julia> using Graphs
+
+julia> g = complete_graph(4);
+
+julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
+
+julia> spfa_shortest_paths(g, 1, d)
+4-element Vector{Int64}:
+  0
+  0
+ -1
+  0
+```
+
+```
+
 julia> g = complete_graph(3);
 
 julia> d = [1 -3 1; -3 1 1; 1 1 1];
@@ -25,20 +41,7 @@ julia> d = [1 -3 1; -3 1 1; 1 1 1];
 julia> spfa_shortest_paths(g, 1, d)
 
 ERROR: Graphs.NegativeCycleError()
-
-julia> g = complete_graph(4);
-
-julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
-
-julia> spfa_shortest_paths(gx, 1, d)
-
-4-element Array{Int64,1}:
-  0
-  0
- -1
-  0
 ```
-
 """
 function spfa_shortest_paths(
     graph::AbstractGraph{U}, source::Integer, distmx::AbstractMatrix{T}=weights(graph)
@@ -91,6 +94,8 @@ Function which returns true if there is any negative weight cycle in the graph.
 # Examples
 
 ```jldoctest
+julia> using Graphs
+
 julia> g = complete_graph(3);
 
 julia> d = [1 -3 1; -3 1 1; 1 1 1];
@@ -102,7 +107,7 @@ julia> g = complete_graph(4);
 
 julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
 
-julia> has_negative_edge_cycle_spfa(g, d);
+julia> has_negative_edge_cycle_spfa(g, d)
 false
 ```
 

--- a/src/traversals/bipartition.jl
+++ b/src/traversals/bipartition.jl
@@ -16,7 +16,7 @@ julia> using Graphs
 julia> g = SimpleGraph(3);
 
 julia> bipartite_map(g)
-3-element Array{UInt8,1}:
+3-element Vector{UInt8}:
  0x01
  0x01
  0x01
@@ -28,9 +28,12 @@ julia> add_edge!(g, 1, 2);
 julia> add_edge!(g, 2, 3);
 
 julia> bipartite_map(g)
-3-element Array{UInt8,1}:
+6-element Vector{UInt8}:
  0x01
  0x02
+ 0x01
+ 0x01
+ 0x01
  0x01
 ```
 """

--- a/src/vertexcover/degree_vertex_cover.jl
+++ b/src/vertexcover/degree_vertex_cover.jl
@@ -21,11 +21,11 @@ Memory: O(|V|)
 julia> using Graphs
 
 julia> vertex_cover(path_graph(3), DegreeVertexCover())
-1-element Array{Int64,1}:
+1-element Vector{Int64}:
  2
 
 julia> vertex_cover(cycle_graph(3), DegreeVertexCover())
-2-element Array{Int64,1}:
+2-element Vector{Int64}:
  1
  3
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ end
 end
 
 @testset verbose = true "Doctests (Documenter.jl)" begin
-    # doctest(Graphs)  # TODO: uncomment it when the errors it throws are fixed
+    doctest(Graphs)
 end
 
 function testgraphs(g)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,9 +25,7 @@ end
     @test format(Graphs; verbose=false, overwrite=false, ignore="vf2.jl")  # TODO: remove ignore kwarg once the file is formatted correctly
 end
 
-@testset verbose = true "Doctests (Documenter.jl)" begin
-    doctest(Graphs)
-end
+doctest(Graphs)
 
 function testgraphs(g)
     return if is_directed(g)


### PR DESCRIPTION
I have fixed all `jldoctest` as proposed by issue [#192](https://github.com/JuliaGraphs/Graphs.jl/issues/192). 

There are some cases for which I have deactivated the `jldoctest` and which might need further attention.

I have deactivated the following `jldoctest`s

- `modularity.jl` has a reference on `SimpleWeightedGraph` which is not included by Graphs.jl.
- `transitivity.jl` in the function `transitiveClosure`. The issue here is that Documenter.jl truncates the output. Thus, it is not fully visible. We could compare the truncated output instead. However, it might then differ from the output which is seen by the user.
- `shortestpaths.jl` in the function `has_negative_weight_cycle` in `src/Experimental`. The `SPFA` package is not found. The same happens in `spfa.jl`.
- `spfa.jl` in `spfa_shortest_paths`. The output is compared to an error message. However, the full stack trace is obviously not included.
- `euclidiagraphs.jl` uses random values. We might want to add a local doc filter.
- `randgraphs.jl` uses random values. We might want to add a local doc filter here as well.