### PR TITLE
Fix package docstring

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -435,14 +435,13 @@ undirected graphs are supported via separate types, and conversion is available
 from directed to undirected.
 
 The project goal is to mirror the functionality of robust network and graph
-analysis libraries such as NetworkX while being simpler to use and more
-efficient than existing Julian graph libraries such as Graphs.jl. It is an
-explicit design decision that any data not required for graph manipulation
+analysis libraries such as NetworkX while being simple to use and efficient.
+It is an explicit design decision that any data not required for graph manipulation
 (attributes and other information, for example) is expected to be stored
 outside of the graph structure itself. Such data lends itself to storage in
 more traditional and better-optimized mechanisms.
 
-[Full documentation](http://codecov.io/github/JuliaGraphs/Graphs.jl) is available,
+[Full documentation](https://juliagraphs.org/Graphs.jl/stable/) is available,
 and tutorials are available at the
 [JuliaGraphsTutorials repository](https://github.com/JuliaGraphs/JuliaGraphsTutorials).
 """


### PR DESCRIPTION
It can be slightly confusing for user who don't know the package history to say that Graphs.jl is faster than Graphs.jl.

Alos the doc link seemed to be broken.