### PR TITLE
Improve performance of bfs functions

### DIFF
--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -43,15 +43,19 @@ end
 function _bfs_parents(g::AbstractGraph{T}, source, neighborfn::Function) where {T}
     n = nv(g)
     visited = falses(n)
-    parents = zeros(T, nv(g))
+    parents = zeros(T, n)
     cur_level = Vector{T}()
     sizehint!(cur_level, n)
     next_level = Vector{T}()
     sizehint!(next_level, n)
+    k = 0
     @inbounds for s in source
-        visited[s] = true
-        push!(cur_level, s)
-        parents[s] = s
+        if !visited[s]
+            visited[s] = true
+            push!(cur_level, s)
+            parents[s] = s
+            k += 1
+        end
     end
     while !isempty(cur_level)
         @inbounds for v in cur_level
@@ -60,8 +64,10 @@ function _bfs_parents(g::AbstractGraph{T}, source, neighborfn::Function) where {
                     push!(next_level, i)
                     parents[i] = v
                     visited[i] = true
+                    k += 1
                 end
             end
+            k == n && return parents
         end
         empty!(cur_level)
         cur_level, next_level = next_level, cur_level
@@ -105,10 +111,14 @@ function gdistances!(g::AbstractGraph{T}, source, vert_level; sort_alg=QuickSort
     sizehint!(cur_level, n)
     next_level = Vector{T}()
     sizehint!(next_level, n)
+    k = 0
     @inbounds for s in source
-        vert_level[s] = zero(T)
-        visited[s] = true
-        push!(cur_level, s)
+        if !visited[s]
+            vert_level[s] = zero(T)
+            visited[s] = true
+            push!(cur_level, s)
+            k += 1
+        end
     end
     while !isempty(cur_level)
         @inbounds for v in cur_level
@@ -117,8 +127,10 @@ function gdistances!(g::AbstractGraph{T}, source, vert_level; sort_alg=QuickSort
                     push!(next_level, i)
                     vert_level[i] = n_level
                     visited[i] = true
+                    k += 1
                 end
             end
+            k == n && return vert_level
         end
         n_level += one(T)
         empty!(cur_level)


### PR DESCRIPTION
I added an optimization to these bfs functions which I benchmarked with

```julia
using Graphs, BenchmarkTools

gs = [path_graph(500),
      path_graph(5000),
      path_graph(50000),
      erdos_renyi(50, 0.5, seed=123),
      erdos_renyi(500, 0.5, seed=123),
      erdos_renyi(5000, 0.5, seed=123),
      complete_graph(50),
      complete_graph(500),
      complete_graph(5000)]

for g in gs
    n = nv(g)
    u = Int(n/5)
    dists = vec(fill(typemax(Int), (1, n)))
    t_1 = @belapsed gdistances!($g, $u, $dists)
    t_2 = @belapsed bfs_parents($g, $u)
    println("$t_1 $t_2;")
end
```
and then I calculated the relative speed-up for the graphs in `gs` before and after this pr:

``` julia
 gdistances! bfs_parents
     0.99      0.99            --> path_graph(500)
     0.98      0.99            --> path_graph(5000)
     0.99      1.00            --> path_graph(50000)
     3.18      3.14            --> erdos_renyi(50, 0.5, seed=123)
    16.91      15.42           --> erdos_renyi(500, 0.5, seed=123)
   126.52      120.08          --> erdos_renyi(5000, 0.5, seed=123)
     5.40      5.19            --> complete_graph(50)
    46.14      40.11           --> complete_graph(500)
   512.26      475.42          --> complete_graph(5000)
```

The Path Graph is kind of the worst case scenario, and the time is approximately equal to the algorithm before this pr, but, as you can see, with a well connected Erdos Renyi the speed-up becomes very good, and finally I choose to benchmark a Complete Graph since it should be the best case scenario. 

I also ran the tests locally and everything should still work!
