### PR TITLE
New SimpleGraph constructor from tuples

### DIFF
--- a/src/SimpleGraphs/simplegraph.jl
+++ b/src/SimpleGraphs/simplegraph.jl
@@ -15,8 +15,31 @@ mutable struct SimpleGraph{T<:Integer} <: AbstractSimpleGraph{T}
     end
 end
 
-function SimpleGraph(ne, fadjlist::Vector{Vector{T}}) where {T}
+function SimpleGraph(ne::Integer, fadjlist::Vector{Vector{T}}) where {T}
     return SimpleGraph{T}(ne, fadjlist)
+end
+
+# initialize a graph by a vector of tuples
+"""
+    SimpleGraph{T}(n, tuples_as_edges)
+
+Construct a `SimpleGraph{T}` with `n` vertices, with the edges specified as a vector of tuples.
+The element type `T` is the type of `n`.
+
+## Examples
+```jldoctest
+julia> using Graphs
+
+julia> SimpleGraph(UInt8(10), [(1,2), (2, 3)])
+{10, 2} undirected simple UInt8 graph
+```
+"""
+function SimpleGraph(n::Integer, tuples_as_edges::AbstractVector{Tuple{T,T}}) where {T<:Integer}
+    g = SimpleGraph{typeof(n)}(n)
+    for (i, j) in tuples_as_edges
+        add_edge!(g, i, j)
+    end
+    return g
 end
 
 eltype(x::SimpleGraph{T}) where {T} = T
@@ -299,7 +322,7 @@ function _SimpleGraphFromIterator(iter)::SimpleGraph
     g = SimpleGraph{T}()
     fadjlist = Vector{Vector{T}}()
 
-    while next != nothing
+    while next !== nothing
         (e, state) = next
 
         if !(e isa E)

--- a/test/simplegraphs/simplegraphs.jl
+++ b/test/simplegraphs/simplegraphs.jl
@@ -498,4 +498,11 @@ using Random: Random
     end
     # codecov for has_edge(::AbstractSimpleGraph, x, y)
     @test @inferred has_edge(DummySimpleGraph(), 1, 2)
+
+    @testset "Constructors from tuples" begin
+        g = SimpleGraph(Int32(4), [(1, 2), (2, 3)])
+        @test g isa SimpleGraph{Int32}
+        @test nv(g) == 4
+        @test ne(g) == 2
+    end
 end


### PR DESCRIPTION
From the slack discussion. We already have the
`SimpleGraphFromIterator(vector_of_edges)` https://juliagraphs.org/Graphs.jl/dev/first_steps/construction/#Modifying-graphs (@gdalle )

However, I think this new interface might still be very useful
1. It does not require converting tuples to the `Edge` type.
2. Allows setting the number of vertices, which I think is very important when constructing graphs programmingly.

In mathematics, we also use tuple of length 2 to represent a pair of undirected edges $(i, j) \in E$. To me, it is natural notation. Comments are welcomes.

## Example
**Before**
```julia
g = SimpleGraph(Int32(4))

for (i, j) in  [(1, 2), (2, 3)]
    add_edge!(g, i, j)
end
```

**After**
```julia
g = SimpleGraph(Int32(4), [(1, 2), (2, 3)])
```