### PR TITLE
Revert the error thrown by badj to NotImplementedError

### DIFF
--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -142,7 +142,7 @@ edges(g::AbstractSimpleGraph) = SimpleEdgeIter(g)
 fadj(g::AbstractSimpleGraph) = g.fadjlist
 fadj(g::AbstractSimpleGraph, v::Integer) = g.fadjlist[v]
 
-function badj end
+badj(x...) = _NI("badj")
 
 # handles single-argument edge constructors such as pairs and tuples
 has_edge(g::AbstractSimpleGraph, x) = has_edge(g, edgetype(g)(x))

--- a/test/simplegraphs/simplegraphs.jl
+++ b/test/simplegraphs/simplegraphs.jl
@@ -9,7 +9,7 @@ using Random: Random
     @test @inferred(eltype(SimpleGraph(adjmx1))) == Int
     @test_throws ArgumentError SimpleGraph(adjmx2)
 
-    @test_throws MethodError badj(DummySimpleGraph())
+    @test_throws Graphs.NotImplementedError badj(DummySimpleGraph())
 
     @test @inferred(ne(SimpleGraph(path_digraph(5)))) == 4
     @test @inferred(!is_directed(SimpleGraph))


### PR DESCRIPTION
This PR reverts the change that was done to `badj` in #249 , as apparently it is not necessary to change the error in order to satisfy JET.jl.

There are still some good arguments for and also against throwing a custom error message when an interface method is not implemented, but I think that needs a separate discussion as we still have the pattern where we throw `NotImplementedError` in various places, so we should not simply change it for that single function.