### PR TITLE
Add ignore_missing_comparison=true for JET tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,8 +30,8 @@ end
 
 @testset "Code quality (JET.jl)" begin
     if VERSION >= v"1.9"
-        @assert get_pkg_version("JET") >= v"0.8.3"
-        JET.test_package(Graphs; target_defined_modules=true)
+        @assert get_pkg_version("JET") >= v"0.8.4"
+        JET.test_package(Graphs; target_defined_modules=true, ignore_missing_comparison=true)
     end
 end
 


### PR DESCRIPTION
For testing with JET `>= 0.8.4` we need to specify `ignore_missing_comparison=true` in order for the type inference test with the `==` operator to correctly work.

See: https://github.com/aviatesk/JET.jl/releases/tag/v0.8.4