### PR TITLE
Test centrality with generic graph

### DIFF
--- a/src/centrality/betweenness.jl
+++ b/src/centrality/betweenness.jl
@@ -81,7 +81,7 @@ function betweenness_centrality(
 )
     return betweenness_centrality(
         g,
-        sample(vertices(g), k; rng=rng, seed=seed),
+        sample(collect_if_not_vector(vertices(g)), k; rng=rng, seed=seed),
         distmx;
         normalize=normalize,
         endpoints=endpoints,
@@ -124,8 +124,7 @@ function _accumulate_endpoints!(
     v1 = collect(Base.OneTo(n_v))
     v2 = state.dists
     S = reverse(state.closest_vertices)
-    s = vertices(g)[si]
-    betweenness[s] += length(S) - 1    # 289
+    betweenness[si] += length(S) - 1    # 289
 
     for w in S
         coeff = (1.0 + δ[w]) / σ[w]

--- a/src/centrality/stress.jl
+++ b/src/centrality/stress.jl
@@ -51,7 +51,7 @@ function stress_centrality(
     rng::Union{Nothing,AbstractRNG}=nothing,
     seed::Union{Nothing,Integer}=nothing,
 )
-    return stress_centrality(g, sample(vertices(g), k; rng=rng, seed=seed))
+    return stress_centrality(g, sample(collect_if_not_vector(vertices(g)), k; rng=rng, seed=seed))
 end
 
 function _stress_accumulate_basic!(

--- a/src/core.jl
+++ b/src/core.jl
@@ -44,6 +44,10 @@ julia> add_vertices!(g, 2)
 """
 add_vertices!(g::AbstractGraph, n::Integer) = sum([add_vertex!(g) for i in 1:n])
 
+# TODO the behaviour of indegree (and as well outdegree and degree) is very
+# badly documented for the case indegree(g, vs) where vs is not a single vertex
+# but rather a collection of vertices
+
 """
     indegree(g[, v])
 
@@ -68,7 +72,7 @@ julia> indegree(g)
 ```
 """
 indegree(g::AbstractGraph, v::Integer) = length(inneighbors(g, v))
-indegree(g::AbstractGraph, v::AbstractVector=vertices(g)) = [indegree(g, x) for x in v]
+indegree(g::AbstractGraph, vs=vertices(g)) = [indegree(g, x) for x in vs]
 
 """
     outdegree(g[, v])
@@ -94,7 +98,7 @@ julia> outdegree(g)
 ```
 """
 outdegree(g::AbstractGraph, v::Integer) = length(outneighbors(g, v))
-outdegree(g::AbstractGraph, v::AbstractVector=vertices(g)) = [outdegree(g, x) for x in v]
+outdegree(g::AbstractGraph, vs=vertices(g)) = [outdegree(g, x) for x in vs]
 
 """
     degree(g[, v])
@@ -122,10 +126,16 @@ julia> degree(g)
 ```
 """
 function degree end
-@traitfn degree(g::::IsDirected, v::Integer) = indegree(g, v) + outdegree(g, v)
-@traitfn degree(g::::(!IsDirected), v::Integer) = indegree(g, v)
 
-degree(g::AbstractGraph, v::AbstractVector=vertices(g)) = [degree(g, x) for x in v]
+function degree(g::AbstractGraph, v::Integer)
+    if !is_directed(g)
+        return outdegree(g, v)
+    end
+    return indegree(g, v) + outdegree(g, v)
+end
+
+degree(g::AbstractGraph, vs=vertices(g)) = [degree(g, x) for x in vs]
+
 
 """
     Δout(g)

--- a/test/centrality/betweenness.jl
+++ b/test/centrality/betweenness.jl
@@ -1,17 +1,15 @@
 @testset "Betweenness" begin
     rng = StableRNG(1)
     # self loops
-    s2 = SimpleDiGraph(3)
-    add_edge!(s2, 1, 2)
-    add_edge!(s2, 2, 3)
-    add_edge!(s2, 3, 3)
-    s1 = SimpleGraph(s2)
-    g3 = path_graph(5)
+    s1 = GenericGraph(SimpleGraph(Edge.([(1,2), (2,3), (3, 3)])))
+    s2 = GenericDiGraph(SimpleDiGraph(Edge.([(1,2), (2,3), (3, 3)])))
+
+    g3 = GenericGraph(path_graph(5))
 
     gint = loadgraph(joinpath(testdir, "testdata", "graph-50-500.jgz"), "graph-50-500")
 
     c = vec(readdlm(joinpath(testdir, "testdata", "graph-50-500-bc.txt"), ','))
-    for g in testdigraphs(gint)
+    for g in test_generic_graphs(gint)
         z = @inferred(betweenness_centrality(g))
         @test map(Float32, z) == map(Float32, c)
 
@@ -29,25 +27,18 @@
     @test @inferred(betweenness_centrality(s1)) == [0, 1, 0]
     @test @inferred(betweenness_centrality(s2)) == [0, 0.5, 0]
 
-    g = SimpleGraph(2)
-    add_edge!(g, 1, 2)
+    g = GenericGraph(path_graph(2))
     z = @inferred(betweenness_centrality(g; normalize=true))
     @test z[1] == z[2] == 0.0
     z2 = @inferred(betweenness_centrality(g, vertices(g)))
-    z3 = @inferred(betweenness_centrality(g, [vertices(g);]))
+    z3 = @inferred(betweenness_centrality(g, collect(vertices(g))))
     @test z == z2 == z3
 
     z = @inferred(betweenness_centrality(g3; normalize=false))
     @test z[1] == z[5] == 0.0
 
     # Weighted Graph tests
-    g = Graph(6)
-    add_edge!(g, 1, 2)
-    add_edge!(g, 2, 3)
-    add_edge!(g, 3, 4)
-    add_edge!(g, 2, 5)
-    add_edge!(g, 5, 6)
-    add_edge!(g, 5, 4)
+    g = GenericGraph(SimpleGraph(Edge.([(1, 2), (2, 3), (2, 5), (3, 4), (4, 5), (5, 6)])))
 
     distmx = [
         0.0 2.0 0.0 0.0 0.0 0.0
@@ -77,7 +68,7 @@
 
     adjmx2 = [0 1 0; 1 0 1; 1 1 0] # digraph
     a2 = SimpleDiGraph(adjmx2)
-    for g in testdigraphs(a2)
+    for g in test_generic_graphs(a2)
         distmx2 = [Inf 2.0 Inf; 3.2 Inf 4.2; 5.5 6.1 Inf]
         c2 = [0.24390243902439027, 0.27027027027027023, 0.1724137931034483]
         @test isapprox(
@@ -99,7 +90,7 @@
         )
     end
     # test #1405 / #1406
-    g = grid([50, 50])
+    g = GenericGraph(grid([50, 50]))
     z = betweenness_centrality(g; normalize=false)
     @test maximum(z) < nv(g) * (nv(g) - 1)
 end

--- a/test/centrality/closeness.jl
+++ b/test/centrality/closeness.jl
@@ -5,7 +5,7 @@
     add_edge!(g5, 1, 3)
     add_edge!(g5, 3, 4)
 
-    for g in testdigraphs(g5)
+    for g in test_generic_graphs(g5)
         y = @inferred(closeness_centrality(g; normalize=false))
         z = @inferred(closeness_centrality(g))
         @test y == [0.75, 0.6666666666666666, 1.0, 0.0]
@@ -14,7 +14,7 @@
 
     adjmx2 = [0 1 0; 1 0 1; 1 1 0] # digraph
     a2 = SimpleDiGraph(adjmx2)
-    for g in testdigraphs(a2)
+    for g in test_generic_graphs(a2)
         distmx2 = [Inf 2.0 Inf; 3.2 Inf 4.2; 5.5 6.1 Inf]
         c2 = [0.24390243902439027, 0.27027027027027023, 0.1724137931034483]
         y = @inferred(closeness_centrality(g, distmx2; normalize=false))
@@ -25,7 +25,7 @@
 
     g5 = SimpleGraph(5)
     add_edge!(g5, 1, 2)
-    for g in testgraphs(g5)
+    for g in test_generic_graphs(g5)
         z = @inferred(closeness_centrality(g))
         @test z[1] == z[2] == 0.25
         @test z[3] == z[4] == z[5] == 0.0
@@ -33,7 +33,7 @@
 
     adjmx1 = [0 1 0; 1 0 1; 0 1 0] # graph
     a1 = SimpleGraph(adjmx1)
-    for g in testgraphs(a1)
+    for g in test_generic_graphs(a1)
         distmx1 = [Inf 2.0 Inf; 2.0 Inf 4.2; Inf 4.2 Inf]
         c1 = [0.24390243902439027, 0.3225806451612903, 0.1923076923076923]
         y = @inferred(closeness_centrality(g, distmx1; normalize=false))

--- a/test/centrality/degree.jl
+++ b/test/centrality/degree.jl
@@ -4,7 +4,7 @@
     add_edge!(g5, 2, 3)
     add_edge!(g5, 1, 3)
     add_edge!(g5, 3, 4)
-    for g in testdigraphs(g5)
+    for g in test_generic_graphs(g5)
         @test @inferred(degree_centrality(g)) ==
             [0.6666666666666666, 0.6666666666666666, 1.0, 0.3333333333333333]
         @test @inferred(indegree_centrality(g, normalize=false)) == [0.0, 1.0, 2.0, 1.0]

--- a/test/centrality/eigenvector.jl
+++ b/test/centrality/eigenvector.jl
@@ -2,7 +2,7 @@
     g1 = smallgraph(:house)
     g2 = cycle_digraph(4)
 
-    for g in testgraphs(g1)
+    for g in test_generic_graphs(g1)
         y = @inferred(eigenvector_centrality(g))
         @test round.(y, digits=3) ==
             round.(
@@ -16,7 +16,7 @@
             digits=3,
         )
     end
-    for g in testdigraphs(g2)
+    for g in test_generic_graphs(g2)
         y = @inferred(eigenvector_centrality(g))
         @test round.(y, digits=3) == round.([0.5, 0.5, 0.5, 0.5], digits=3)
     end

--- a/test/centrality/katz.jl
+++ b/test/centrality/katz.jl
@@ -4,7 +4,7 @@
     add_edge!(g5, 2, 3)
     add_edge!(g5, 1, 3)
     add_edge!(g5, 3, 4)
-    for g in testdigraphs(g5)
+    for g in test_generic_graphs(g5)
         z = @inferred(katz_centrality(g, 0.4))
         @test round.(z, digits=2) == [0.32, 0.44, 0.62, 0.56]
     end

--- a/test/centrality/pagerank.jl
+++ b/test/centrality/pagerank.jl
@@ -23,7 +23,7 @@
     add_edge!(g6, 1, 3)
     add_edge!(g6, 3, 4)
     for α in [0.75, 0.85]
-        for g in testdigraphs(g5)
+        for g in test_generic_graphs(g5)
             @test pagerank(g)[3] ≈ 0.318 atol = 0.001
             @test length(@inferred(pagerank(g))) == nv(g)
             @test_throws ErrorException pagerank(g, 2)
@@ -31,7 +31,7 @@
             @test isapprox(pagerank(g, α), dense_pagerank_solver(g, α), atol=0.001)
         end
 
-        for g in testgraphs(g6)
+        for g in test_generic_graphs(g6)
             @test length(@inferred(pagerank(g))) == nv(g)
             @test_throws ErrorException pagerank(g, 2)
             @test_throws ErrorException pagerank(g, α, 2)

--- a/test/centrality/radiality.jl
+++ b/test/centrality/radiality.jl
@@ -2,7 +2,7 @@
     gint = loadgraph(joinpath(testdir, "testdata", "graph-50-500.jgz"), "graph-50-500")
 
     c = vec(readdlm(joinpath(testdir, "testdata", "graph-50-500-rc.txt"), ','))
-    for g in testdigraphs(gint)
+    for g in test_generic_graphs(gint)
         z = @inferred(radiality_centrality(g))
         @test z == c
     end
@@ -10,7 +10,7 @@
     g1 = cycle_graph(4)
     add_vertex!(g1)
     add_edge!(g1, 4, 5)
-    for g in testgraphs(g1)
+    for g in test_generic_graphs(g1)
         z = @inferred(radiality_centrality(g))
         @test z ≈ [5//6, 3//4, 5//6, 11//12, 2//3]
     end

--- a/test/centrality/stress.jl
+++ b/test/centrality/stress.jl
@@ -3,7 +3,7 @@
     gint = loadgraph(joinpath(testdir, "testdata", "graph-50-500.jgz"), "graph-50-500")
 
     c = vec(readdlm(joinpath(testdir, "testdata", "graph-50-500-sc.txt"), ','))
-    for g in testdigraphs(gint)
+    for g in test_generic_graphs(gint)
         z = @inferred(stress_centrality(g))
         @test z == c
 
@@ -16,7 +16,7 @@
     g1 = cycle_graph(4)
     add_vertex!(g1)
     add_edge!(g1, 4, 5)
-    for g in testgraphs(g1)
+    for g in test_generic_graphs(g1)
         z = @inferred(stress_centrality(g))
         @test z == [4, 2, 4, 10, 0]
     end


### PR DESCRIPTION
This PR changes the centrality algorithms so that they test with GenericGraph instead of SimpleGraph.

Some tests did fail, because we passed the output of `vertices(g)` to `degree` - but previously that function would not only accept an `AbstractVector` and not a generic collection of vertices, so I changed `indegree`, `outdegree` and `degree`, so that they can take an arbitrary collection of vertices. Maybe in the future, we could also just demand, that `vertices(g)` returns an `AbstractVector`.

Furthermore there was an issue with `betweenness_centrality` where we tried to index into `vertices(g)` - this also would have been a non-issue, if `vertices(g)` was an `AbstractVector`.

Lastly, I had to change the input in the `sample` method, that could also not deal with the output of `vertices(g)`.
