### PR TITLE
Test community with generic graph

### DIFF
--- a/src/community/clustering.jl
+++ b/src/community/clustering.jl
@@ -38,7 +38,7 @@ end
 function local_clustering!(storage::AbstractVector{Bool}, g::AbstractGraph, v::Integer)
     k = degree(g, v)
     k <= 1 && return (0, 0)
-    neighs = neighbors(g, v)
+    neighs = collect_if_not_vector(neighbors(g, v))
     tcount = 0
     storage[neighs] .= true
 
@@ -63,7 +63,7 @@ function local_clustering!(
     i = 0
     for (i, v) in enumerate(vs)
         ntriang[i], nalltriang[i] = local_clustering!(storage, g, v)
-        storage[neighbors(g, v)] .= false
+        storage[collect_if_not_vector(neighbors(g, v))] .= false
     end
     return ntriang, nalltriang
 end

--- a/test/community/assortativity.jl
+++ b/test/community/assortativity.jl
@@ -4,12 +4,12 @@ using Statistics
     # Test definition of assortativity as Pearson correlation coefficient
     # between excess of degrees
     @testset "Small graphs" for n in 5:10
-        @test @inferred assortativity(wheel_graph(n)) ≈ -1 / 3
+        @test @inferred assortativity(GenericGraph(wheel_graph(n))) ≈ -1 / 3
     end
     @testset "Directed ($seed)" for seed in [1, 2, 3],
         (n, ne) in [(14, 18), (10, 22), (7, 16)]
 
-        g = erdos_renyi(n, ne; is_directed=true, rng=StableRNG(seed))
+        g = GenericDiGraph(erdos_renyi(n, ne; is_directed=true, rng=StableRNG(seed)))
         assort = assortativity(g)
         x = [outdegree(g, src(d)) - 1 for d in edges(g)]
         y = [indegree(g, dst(d)) - 1 for d in edges(g)]
@@ -18,7 +18,7 @@ using Statistics
     @testset "Undirected ($seed)" for seed in [1, 2, 3],
         (n, ne) in [(14, 18), (10, 22), (7, 16)]
 
-        g = erdos_renyi(n, ne; is_directed=false, rng=StableRNG(seed))
+        g = GenericGraph(erdos_renyi(n, ne; is_directed=false, rng=StableRNG(seed)))
         assort = assortativity(g)
         x = [outdegree(g, src(d)) - 1 for d in edges(g)]
         y = [indegree(g, dst(d)) - 1 for d in edges(g)]

--- a/test/community/clique_percolation.jl
+++ b/test/community/clique_percolation.jl
@@ -15,5 +15,5 @@
     add_edge!(g, 1, 4)
     add_edge!(g, 4, 5)
     add_edge!(g, 5, 1)
-    @test test_cliques(g, Array[[1, 2, 3], [1, 4, 5]])
+    @test test_cliques(GenericGraph(g), Array[[1, 2, 3], [1, 4, 5]])
 end

--- a/test/community/cliques.jl
+++ b/test/community/cliques.jl
@@ -17,11 +17,11 @@
 
     gx = SimpleGraph(3)
     add_edge!(gx, 1, 2)
-    for g in testgraphs(gx)
+    for g in test_generic_graphs(gx)
         @test test_cliques(g, Array[[1, 2], [3]])
     end
     add_edge!(gx, 2, 3)
-    for g in testgraphs(gx)
+    for g in test_generic_graphs(gx)
         @test test_cliques(g, Array[[1, 2], [2, 3]])
     end
     # Test for "pivotdonenbrs not defined" bug
@@ -35,7 +35,7 @@
     add_edge!(h, 3, 6)
     add_edge!(h, 5, 6)
 
-    for g in testgraphs(h)
+    for g in test_generic_graphs(h)
         @test !isempty(@inferred(maximal_cliques(g)))
     end
 
@@ -49,7 +49,7 @@
     add_edge!(h, 4, 5)
     add_edge!(h, 4, 7)
     add_edge!(h, 5, 7)
-    for g in testgraphs(h)
+    for g in test_generic_graphs(h)
         @test test_cliques(h, Array[[7, 4, 5], [2, 6], [3, 5], [3, 6], [3, 1]])
     end
 end

--- a/test/community/clustering.jl
+++ b/test/community/clustering.jl
@@ -1,6 +1,6 @@
 @testset "Clustering" begin
     g10 = complete_graph(10)
-    for g in testgraphs(g10)
+    for g in test_generic_graphs(g10)
         @test @inferred(local_clustering_coefficient(g, 1)) == 1.0
         @test @inferred(local_clustering_coefficient(g)) == ones(10)
         @test @inferred(global_clustering_coefficient(g)) == 1.0
@@ -11,5 +11,5 @@
     # 1265 / 1266
     g = complete_graph(3)
     add_edge!(g, 2, 2)
-    @test @inferred(triangles(g)) == fill(1, 3)
+    @test @inferred(triangles(GenericGraph(g))) == fill(1, 3)
 end

--- a/test/community/core-periphery.jl
+++ b/test/community/core-periphery.jl
@@ -1,6 +1,6 @@
 @testset "Core periphery" begin
     g10 = star_graph(10)
-    for g in testgraphs(g10)
+    for g in test_generic_graphs(g10)
         c = core_periphery_deg(g)
         @test @inferred(degree(g, 1)) == 9
         @test c[1] == 1
@@ -12,7 +12,7 @@
     g10 = star_graph(10)
     g10 = blockdiag(g10, g10)
     add_edge!(g10, 1, 11)
-    for g in testgraphs(g10)
+    for g in test_generic_graphs(g10)
         c = @inferred(core_periphery_deg(g))
         @test c[1] == 1
         @test c[11] == 1

--- a/test/community/label_propagation.jl
+++ b/test/community/label_propagation.jl
@@ -7,7 +7,7 @@
         for k in 2:5
             z = blockdiag(z, g)
             add_edge!(z, (k - 1) * n, k * n)
-            c, ch = @inferred(label_propagation(z; rng=rng))
+            c, ch = @inferred(label_propagation(GenericGraph(z); rng=rng))
             a = collect(n:n:(k * n))
             a = Int[div(i - 1, n) + 1 for i in 1:(k * n)]
             # check the number of communities

--- a/test/community/modularity.jl
+++ b/test/community/modularity.jl
@@ -5,20 +5,19 @@
     m = n * (n - 1) / 2
     c = ones(Int, n)
     gint = complete_graph(n)
-    for g in testgraphs(gint)
+    for g in test_generic_graphs(gint)
         @test @inferred(modularity(g, c)) == 0
     end
 
     gint = SimpleGraph(n)
-    for g in testgraphs(gint)
+    for g in test_generic_graphs(gint)
         @test @inferred(modularity(g, c)) == 0
     end
 
-    barbell = blockdiag(complete_graph(3), complete_graph(3))
-    add_edge!(barbell, 1, 4)
+    barbell = barbell_graph(3, 3)
     c = [1, 1, 1, 2, 2, 2]
 
-    for g in testgraphs(barbell)
+    for g in test_generic_graphs(barbell)
         Q1 = @inferred(modularity(g, c))
         @test isapprox(Q1, 0.35714285714285715, atol=1e-3)
         Q2 = @inferred(modularity(g, c, γ=0.5))
@@ -35,7 +34,7 @@
     add_edge!(barbell, 1, 4)
     c = [1, 1, 1, 2, 2, 2]
 
-    for g in testdigraphs(barbell)
+    for g in test_generic_graphs(barbell)
         Q1 = @inferred(modularity(g, c))
         @test isapprox(Q1, 0.3673469387755103, atol=1e-3)
 
@@ -44,29 +43,25 @@
     end
 
     add_edge!(barbell, 4, 1)
-    for g in testdigraphs(barbell)
+    for g in test_generic_graphs(barbell)
         @test @inferred(modularity(g, c)) == 0.25
     end
 
     # 3. weighted test cases 
     # 3.1. undirected and weighted test cases
-    triangle = SimpleGraph(3)
-    add_edge!(triangle, 1, 2)
-    add_edge!(triangle, 2, 3)
-    add_edge!(triangle, 3, 1)
 
-    barbell = blockdiag(triangle, triangle)
-    add_edge!(barbell, 1, 4) # this edge has a weight of 5
+    # the "handle" of the barbell 3--4 gets a weight of 5
+    barbell = barbell_graph(3, 3)
     c = [1, 1, 1, 2, 2, 2]
     d = [
-        [0 1 1 5 0 0]
+        [0 1 1 0 0 0]
         [1 0 1 0 0 0]
-        [1 1 0 0 0 0]
-        [5 0 0 0 1 1]
+        [1 1 0 5 0 0]
+        [0 0 5 0 1 1]
         [0 0 0 1 0 1]
         [0 0 0 1 1 0]
     ]
-    for g in testgraphs(barbell)
+    for g in test_generic_graphs(barbell)
         Q = @inferred(modularity(g, c, distmx=d))
         @test isapprox(Q, 0.045454545454545456, atol=1e-3)
     end
@@ -88,7 +83,7 @@
         [0 0 0 0 0 1]
         [0 0 0 1 0 0]
     ]
-    for g in testdigraphs(barbell)
+    for g in test_generic_graphs(barbell)
         Q = @inferred(modularity(g, c, distmx=d))
         @test isapprox(Q, 0.1487603305785124, atol=1e-3)
     end

--- a/test/community/rich_club.jl
+++ b/test/community/rich_club.jl
@@ -2,20 +2,20 @@
 @testset "Rich club coefficient" begin
     rng = StableRNG(1)
     @testset "Small graphs" for _n in 5:10
-        @test @inferred rich_club(star_graph(_n), 1) ≈ 2 / _n
-        @test @inferred rich_club(DiGraph(star_graph(_n)), 1) ≈ 2 / _n
+        @test @inferred rich_club(GenericGraph(star_graph(_n)), 1) ≈ 2 / _n
+        @test @inferred rich_club(GenericDiGraph(DiGraph(star_graph(_n))), 1) ≈ 2 / _n
     end
     @testset "Directed ($seed)" for seed in [1, 2, 3],
         (n, ne) in [(14, 18), (10, 22), (7, 16)]
 
-        g = erdos_renyi(n, ne; is_directed=true, rng=StableRNG(seed))
+        g = GenericDiGraph(erdos_renyi(n, ne; is_directed=true, rng=StableRNG(seed)))
         _r = rich_club(g, 1)
         @test @inferred rich_club(g, 1) > 0.0
     end
     @testset "Undirected ($seed)" for seed in [1, 2, 3],
         (n, ne) in [(14, 18), (10, 22), (7, 16)]
 
-        g = erdos_renyi(n, ne; is_directed=false, rng=StableRNG(seed))
+        g = GenericGraph(erdos_renyi(n, ne; is_directed=false, rng=StableRNG(seed)))
         _r = rich_club(g, 1)
         @test @inferred rich_club(g, 1) > 0.0
     end


### PR DESCRIPTION
This PR makes the tests for the community algorithm use `GenericGraph`

There were only some small changes necessary to `src/community/clustering.jl` to make the tests work.