### PR TITLE
Use GenericGraph for testing shortestpaths algorithms

### DIFF
--- a/src/shortestpaths/bellman-ford.jl
+++ b/src/shortestpaths/bellman-ford.jl
@@ -48,7 +48,8 @@ function bellman_ford_shortest_paths(
     for i in vertices(graph)
         no_changes = true
         new_active .= false
-        for u in vertices(graph)[active]
+        for u in vertices(graph)
+            active[u] || continue
             for v in outneighbors(graph, u)
                 relax_dist = distmx[u, v] + dists[u]
                 if dists[v] > relax_dist
@@ -80,9 +81,10 @@ function has_negative_edge_cycle(
     g::AbstractGraph{U}, distmx::AbstractMatrix{T}
 ) where {T<:Real} where {U<:Integer}
     try
-        bellman_ford_shortest_paths(g, vertices(g), distmx)
+        bellman_ford_shortest_paths(g, collect_if_not_vector(vertices(g)), distmx)
     catch e
         isa(e, NegativeCycleError) && return true
+        rethrow()
     end
     return false
 end

--- a/src/shortestpaths/johnson.jl
+++ b/src/shortestpaths/johnson.jl
@@ -28,7 +28,7 @@ function johnson_shortest_paths(
     nvg = nv(g)
     type_distmx = typeof(distmx)
     # Change when parallel implementation of Bellman Ford available
-    wt_transform = bellman_ford_shortest_paths(g, vertices(g), distmx).dists
+    wt_transform = bellman_ford_shortest_paths(g, collect_if_not_vector(vertices(g)), distmx).dists
 
     @compat if !ismutable(distmx) && type_distmx != Graphs.DefaultDistance
         distmx = sparse(distmx) # Change reference, not value

--- a/src/shortestpaths/yen.jl
+++ b/src/shortestpaths/yen.jl
@@ -1,3 +1,7 @@
+# TODO this algorithm does not work with abitrary AbstractGraph yet,
+# as it relies on rem_edge! and deepcopy
+
+
 """
     struct YenState{T, U}
 

--- a/test/shortestpaths/astar.jl
+++ b/test/shortestpaths/astar.jl
@@ -4,11 +4,20 @@
 
     d1 = float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0])
     d2 = sparse(float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0]))
-    for g in testgraphs(g3), dg in testdigraphs(g4)
+    @testset "SimpleGraph and SimpleDiGraph" for g in testgraphs(g3), dg in testdigraphs(g4)
         @test @inferred(a_star(g, 1, 4, d1)) ==
             @inferred(a_star(dg, 1, 4, d1)) ==
             @inferred(a_star(g, 1, 4, d2))
         @test isempty(@inferred(a_star(dg, 4, 1)))
+    end
+    @testset "GenericGraph and GenricDiGraph with SimpleEdge" for g in test_generic_graphs(g3), dg in test_generic_graphs(g4)
+        zero_heuristic = n -> 0
+        Eg = SimpleEdge{eltype(g)}
+        Edg = SimpleEdge{eltype(dg)}
+        @test @inferred(a_star(g, 1, 4, d1, zero_heuristic, Eg)) ==
+            @inferred(a_star(dg, 1, 4, d1, zero_heuristic, Edg)) ==
+            @inferred(a_star(g, 1, 4, d2, zero_heuristic, Eg))
+        @test isempty(@inferred(a_star(dg, 4, 1, weights(dg), zero_heuristic, Edg)))
     end
 
     # test for #1258
@@ -21,5 +30,5 @@
         s::Int
         d::Int
     end
-    @test eltype(a_star(g, 1, 4, w, n -> 0, MyFavoriteEdgeType)) == MyFavoriteEdgeType
+    @test eltype(a_star(GenericGraph(g), 1, 4, w, n -> 0, MyFavoriteEdgeType)) == MyFavoriteEdgeType
 end

--- a/test/shortestpaths/bellman-ford.jl
+++ b/test/shortestpaths/bellman-ford.jl
@@ -3,7 +3,7 @@
 
     d1 = float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0])
     d2 = sparse(float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0]))
-    for g in testdigraphs(g4)
+    for g in test_generic_graphs(g4)
         y = @inferred(bellman_ford_shortest_paths(g, 2, d1))
         z = @inferred(bellman_ford_shortest_paths(g, 2, d2))
         @test y.dists == z.dists == [Inf, 0, 6, 17, 33]
@@ -24,7 +24,7 @@
 
     # Negative Cycle
     gx = complete_graph(3)
-    for g in testgraphs(gx)
+    for g in test_generic_graphs(gx)
         d = [1 -3 1; -3 1 1; 1 1 1]
         @test_throws Graphs.NegativeCycleError bellman_ford_shortest_paths(g, 1, d)
         @test has_negative_edge_cycle(g, d)
@@ -37,7 +37,7 @@
     # Negative cycle of length 3 in graph of diameter 4
     gx = complete_graph(4)
     d = [1 -1 1 1; 1 1 1 -1; 1 1 1 1; 1 1 1 1]
-    for g in testgraphs(gx)
+    for g in test_generic_graphs(gx)
         @test_throws Graphs.NegativeCycleError bellman_ford_shortest_paths(g, 1, d)
         @test has_negative_edge_cycle(g, d)
     end
@@ -56,7 +56,7 @@
 
     d3 = [CustomReal(i, 3) for i in d1]
     d4 = sparse(d3)
-    for g in testdigraphs(g4)
+    for g in test_generic_graphs(g4)
         y = @inferred(bellman_ford_shortest_paths(g, 2, d3))
         z = @inferred(bellman_ford_shortest_paths(g, 2, d4))
         @test getfield.(y.dists, :val) == getfield.(z.dists, :val) == [Inf, 0, 6, 17, 33]

--- a/test/shortestpaths/desopo-pape.jl
+++ b/test/shortestpaths/desopo-pape.jl
@@ -2,7 +2,7 @@
     g4 = path_digraph(5)
     d1 = float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0])
     d2 = sparse(float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0]))
-    @testset "generic tests: $g" for g in testdigraphs(g4)
+    @testset "generic tests: $(typeof(g))" for g in test_generic_graphs(g4)
         y = @inferred(desopo_pape_shortest_paths(g, 2, d1))
         z = @inferred(desopo_pape_shortest_paths(g, 2, d2))
         @test y.parents == z.parents == [0, 0, 2, 3, 4]
@@ -13,7 +13,7 @@
     add_edge!(gx, 2, 4)
     d = ones(Int, 5, 5)
     d[2, 3] = 100
-    @testset "cycles: $g" for g in testgraphs(gx)
+    @testset "cycles: $(typeof(g))" for g in test_generic_graphs(gx)
         z = @inferred(desopo_pape_shortest_paths(g, 1, d))
         @test z.dists == [0, 1, 3, 2, 3]
         @test z.parents == [0, 1, 4, 2, 4]
@@ -28,7 +28,7 @@
     add_edge!(G, 3, 4)
     add_edge!(G, 4, 5)
 
-    @testset "more cycles: $g" for g in testgraphs(G)
+    @testset "more cycles: $(typeof(g))" for g in test_generic_graphs(G)
         y = @inferred(desopo_pape_shortest_paths(g, 1, m))
         @test y.parents == [0, 1, 1, 3, 3]
         @test y.dists == [0, 2, 2, 3, 4]
@@ -43,7 +43,7 @@
     add_edge!(G, 2, 4)
     add_edge!(G, 4, 5)
     m = [0 10 2 0 15; 10 9 0 1 0; 2 0 1 0 0; 0 1 0 0 2; 15 0 0 2 0]
-    @testset "self loops: $g" for g in testgraphs(G)
+    @testset "self loops: $(typeof(g))" for g in test_generic_graphs(G)
         z = @inferred(desopo_pape_shortest_paths(g, 1, m))
         y = @inferred(dijkstra_shortest_paths(g, 1, m))
         @test isapprox(z.dists, y.dists)
@@ -54,7 +54,7 @@
     add_edge!(G, 1, 3)
     add_edge!(G, 4, 5)
     inf = typemax(eltype(G))
-    @testset "disconnected: $g" for g in testgraphs(G)
+    @testset "disconnected: $(typeof(G))" for g in test_generic_graphs(G)
         z = @inferred(desopo_pape_shortest_paths(g, 1))
         @test z.dists == [0, 1, 1, inf, inf]
         @test z.parents == [0, 1, 1, 0, 0]
@@ -62,7 +62,7 @@
 
     G = SimpleGraph(3)
     inf = typemax(eltype(G))
-    @testset "empty: $g" for g in testgraphs(G)
+    @testset "empty: $(typeof(g))" for g in test_generic_graphs(G)
         z = @inferred(desopo_pape_shortest_paths(g, 1))
         @test z.dists == [0, inf, inf]
         @test z.parents == [0, 0, 0]
@@ -73,7 +73,7 @@
             rng = StableRNG(seed)
             nvg = Int(ceil(250 * rand(rng)))
             neg = Int(floor((nvg * (nvg - 1) / 2) * rand(rng)))
-            g = SimpleGraph(nvg, neg; rng=rng)
+            g = GenericGraph(SimpleGraph(nvg, neg; rng=rng))
             z = desopo_pape_shortest_paths(g, 1)
             y = dijkstra_shortest_paths(g, 1)
             @test isapprox(z.dists, y.dists)
@@ -85,7 +85,7 @@
             rng = StableRNG(seed)
             nvg = Int(ceil(250 * rand(rng)))
             neg = Int(floor((nvg * (nvg - 1) / 2) * rand(rng)))
-            g = SimpleDiGraph(nvg, neg; rng=rng)
+            g = GenericDiGraph(SimpleDiGraph(nvg, neg; rng=rng))
             z = desopo_pape_shortest_paths(g, 1)
             y = dijkstra_shortest_paths(g, 1)
             @test isapprox(z.dists, y.dists)
@@ -93,42 +93,42 @@
     end
 
     @testset "misc graphs" begin
-        G = complete_graph(9)
+        G = GenericGraph(complete_graph(9))
         z = desopo_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
 
-        G = complete_digraph(9)
+        G = GenericDiGraph(complete_digraph(9))
         z = desopo_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
 
-        G = cycle_graph(9)
+        G = GenericGraph(cycle_graph(9))
         z = desopo_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
 
-        G = cycle_digraph(9)
+        G = GenericDiGraph(cycle_digraph(9))
         z = desopo_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
 
-        G = star_graph(9)
+        G = GenericGraph(star_graph(9))
         z = desopo_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
 
-        G = wheel_graph(9)
+        G = GenericGraph(wheel_graph(9))
         z = desopo_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
 
-        G = roach_graph(9)
+        G = GenericGraph(roach_graph(9))
         z = desopo_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
 
-        G = clique_graph(5, 19)
+        G = GenericGraph(clique_graph(5, 19))
         z = desopo_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
@@ -158,16 +158,17 @@
         :truncatedtetrahedron,
         :truncatedtetrahedron_dir,
     ]
-        G = smallgraph(s)
-        z = desopo_pape_shortest_paths(G, 1)
-        y = dijkstra_shortest_paths(G, 1)
+        GS = smallgraph(s)
+        GG = is_directed(GS) ? GenericDiGraph(GS) : GenericGraph(GS)
+        z = desopo_pape_shortest_paths(GG, 1)
+        y = dijkstra_shortest_paths(GG, 1)
         @test isapprox(z.dists, y.dists)
     end
 
     @testset "errors" begin
-        g = Graph()
+        g = GenericGraph(Graph())
         @test_throws DomainError desopo_pape_shortest_paths(g, 1)
-        g = Graph(5)
+        g = GenericGraph(Graph(5))
         @test_throws DomainError desopo_pape_shortest_paths(g, 6)
     end
 end

--- a/test/shortestpaths/dijkstra.jl
+++ b/test/shortestpaths/dijkstra.jl
@@ -3,7 +3,7 @@
     d1 = float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0])
     d2 = sparse(float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0]))
 
-    for g in testdigraphs(g4)
+    for g in test_generic_graphs(g4)
         y = @inferred(dijkstra_shortest_paths(g, 2, d1))
         z = @inferred(dijkstra_shortest_paths(g, 2, d2))
 
@@ -28,7 +28,7 @@
     add_edge!(gx, 2, 4)
     d = ones(Int, 5, 5)
     d[2, 3] = 100
-    for g in testgraphs(gx)
+    for g in test_generic_graphs(gx)
         z = @inferred(dijkstra_shortest_paths(g, 1, d))
         @test z.dists == [0, 1, 3, 2, 3]
         @test z.parents == [0, 1, 4, 2, 4]
@@ -59,7 +59,7 @@
         1.0 0.0 3.0 0.0
     ]
 
-    for g in testgraphs(G)
+    for g in test_generic_graphs(G)
         ds = @inferred(dijkstra_shortest_paths(g, 2, w))
         # this loop reconstructs the shortest path for vertices 1, 3 and 4
         @test spaths(ds, [1, 3, 4], 2) == Array[[2 1], [2 3], [2 1 4]]
@@ -81,7 +81,7 @@
     add_edge!(G, 3, 5)
     add_edge!(G, 3, 4)
     add_edge!(G, 4, 5)
-    for g in testgraphs(G)
+    for g in test_generic_graphs(G)
         ds = @inferred(dijkstra_shortest_paths(g, 1, m; allpaths=true))
         @test ds.pathcounts == [1.0, 1.0, 1.0, 1.0, 2.0]
         @test ds.predecessors == [[], [1], [1], [3], [3, 4]]
@@ -97,7 +97,7 @@
     add_edge!(G, 1, 2)
     add_edge!(G, 1, 3)
     add_edge!(G, 4, 5)
-    for g in testgraphs(G)
+    for g in test_generic_graphs(G)
         dm = @inferred(dijkstra_shortest_paths(g, 1; allpaths=true, trackvertices=true))
         @test dm.closest_vertices == [1, 2, 3, 4, 5]
     end
@@ -107,7 +107,7 @@
         add_edge!(G, 1, 3)
         m = float([0 2 2 0 0 1; 2 0 1 0 0 0; 2 1 0 4 0 0; 0 0 4 0 1 0; 0 0 0 1 0 1; 1 0 0 0 1 0])
 
-        for g in testgraphs(G)
+        for g in test_generic_graphs(G)
             ds = @inferred(dijkstra_shortest_paths(g, 3, m;maxdist=3.0))
             @test ds.dists == [2, 1, 0, Inf, Inf, 3]
         end

--- a/test/shortestpaths/floyd-warshall.jl
+++ b/test/shortestpaths/floyd-warshall.jl
@@ -1,7 +1,7 @@
 @testset "Floyd Warshall" begin
     g3 = path_graph(5)
     d = [0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0]
-    for g in testgraphs(g3)
+    for g in test_generic_graphs(g3)
         z = @inferred(floyd_warshall_shortest_paths(g, d))
         @test z.dists[3, :][:] == [7, 6, 0, 11, 27]
         @test z.parents[3, :][:] == [2, 3, 0, 3, 4]
@@ -14,7 +14,7 @@
     end
     g4 = path_digraph(4)
     d = ones(4, 4)
-    for g in testdigraphs(g4)
+    for g in test_generic_graphs(g4)
         z = @inferred(floyd_warshall_shortest_paths(g, d))
         @test length(enumerate_paths(z, 4, 3)) == 0
         @test length(enumerate_paths(z, 4, 1)) == 0
@@ -23,7 +23,7 @@
 
     g5 = DiGraph([1 1 1 0 1; 0 1 0 1 1; 0 1 1 0 0; 1 0 1 1 0; 0 0 0 1 1])
     d = [0 3 8 0 -4; 0 0 0 1 7; 0 4 0 0 0; 2 0 -5 0 0; 0 0 0 6 0]
-    for g in testdigraphs(g5)
+    for g in test_generic_graphs(g5)
         z = @inferred(floyd_warshall_shortest_paths(g, d))
         @test z.dists == [0 1 -3 2 -4; 3 0 -4 1 -1; 7 4 0 5 3; 2 -1 -5 0 -2; 8 5 1 6 0]
     end
@@ -32,7 +32,7 @@
         g = SimpleGraph(2)
         add_edge!(g, 1, 2)
         add_edge!(g, 2, 2)
-        @test enumerate_paths(floyd_warshall_shortest_paths(g)) ==
+        @test enumerate_paths(floyd_warshall_shortest_paths(GenericGraph(g))) ==
             Vector{Vector{Int}}[[[], [1, 2]], [[2, 1], []]]
 
         g = SimpleDiGraph(2)
@@ -40,7 +40,7 @@
         add_edge!(g, 1, 2)
         add_edge!(g, 2, 1)
         add_edge!(g, 2, 2)
-        @test enumerate_paths(floyd_warshall_shortest_paths(g)) ==
+        @test enumerate_paths(floyd_warshall_shortest_paths(GenericDiGraph(g))) ==
             Vector{Vector{Int}}[[[], [1, 2]], [[2, 1], []]]
     end
 end

--- a/test/shortestpaths/johnson.jl
+++ b/test/shortestpaths/johnson.jl
@@ -1,7 +1,7 @@
 @testset "Johnson" begin
     g3 = path_graph(5)
     d = Symmetric([0 1 2 3 4; 1 0 6 7 8; 2 6 0 11 12; 3 7 11 0 16; 4 8 12 16 0])
-    for g in testgraphs(g3)
+    for g in test_generic_graphs(g3)
         z = @inferred(johnson_shortest_paths(g, d))
         @test z.dists[3, :][:] == [7, 6, 0, 11, 27]
         @test z.parents[3, :][:] == [2, 3, 0, 3, 4]
@@ -14,7 +14,7 @@
     end
 
     g4 = path_digraph(4)
-    for g in testdigraphs(g4)
+    for g in test_generic_graphs(g4)
         z = @inferred(johnson_shortest_paths(g))
         @test length(enumerate_paths(z, 4, 3)) == 0
         @test length(enumerate_paths(z, 4, 1)) == 0
@@ -23,7 +23,7 @@
 
     g5 = DiGraph([1 1 1 0 1; 0 1 0 1 1; 0 1 1 0 0; 1 0 1 1 0; 0 0 0 1 1])
     d = [0 3 8 0 -4; 0 0 0 1 7; 0 4 0 0 0; 2 0 -5 0 0; 0 0 0 6 0]
-    for g in testdigraphs(g5)
+    for g in test_generic_graphs(g5)
         z = @inferred(johnson_shortest_paths(g, d))
         @test z.dists == [0 1 -3 2 -4; 3 0 -4 1 -1; 7 4 0 5 3; 2 -1 -5 0 -2; 8 5 1 6 0]
     end

--- a/test/shortestpaths/spfa.jl
+++ b/test/shortestpaths/spfa.jl
@@ -3,7 +3,7 @@
         g4 = path_digraph(5)
         d1 = float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0])
 
-        for g in testdigraphs(g4)
+        for g in test_generic_graphs(g4)
             y = @inferred(spfa_shortest_paths(g, 2, d1))
             @test y == [Inf, 0, 6, 17, 33]
         end
@@ -13,7 +13,7 @@
             add_edge!(gx, 2, 4)
             d = ones(Int, 5, 5)
             d[2, 3] = 100
-            for g in testgraphs(gx)
+            for g in test_generic_graphs(gx)
                 z = @inferred(spfa_shortest_paths(g, 1, d))
                 @test z == [0, 1, 3, 2, 3]
             end
@@ -28,7 +28,7 @@
         add_edge!(G, 3, 4)
         add_edge!(G, 4, 5)
 
-        for g in testgraphs(G)
+        for g in test_generic_graphs(G)
             y = @inferred(spfa_shortest_paths(g, 1, m))
             @test y == [0, 2, 2, 3, 4]
         end
@@ -44,7 +44,7 @@
         add_edge!(G, 2, 4)
         add_edge!(G, 4, 5)
         m = [0 10 2 0 15; 10 9 0 1 0; 2 0 1 0 0; 0 1 0 0 2; 15 0 0 2 0]
-        for g in testgraphs(G)
+        for g in test_generic_graphs(G)
             z = @inferred(spfa_shortest_paths(g, 1, m))
             y = @inferred(dijkstra_shortest_paths(g, 1, m))
             @test isapprox(z, y.dists)
@@ -57,7 +57,7 @@
         add_edge!(G, 1, 3)
         add_edge!(G, 4, 5)
         inf = typemax(eltype(G))
-        for g in testgraphs(G)
+        for g in test_generic_graphs(G)
             z = @inferred(spfa_shortest_paths(g, 1))
             @test z == [0, 1, 1, inf, inf]
         end
@@ -66,7 +66,7 @@
     @testset "Empty graph" begin
         G = SimpleGraph(3)
         inf = typemax(eltype(G))
-        for g in testgraphs(G)
+        for g in test_generic_graphs(G)
             z = @inferred(spfa_shortest_paths(g, 1))
             @test z == [0, inf, inf]
         end
@@ -78,7 +78,7 @@
                 rng = StableRNG(seed)
                 nvg = Int(ceil(250 * rand(rng)))
                 neg = Int(floor((nvg * (nvg - 1) / 2) * rand(rng)))
-                g = SimpleGraph(nvg, neg; rng=rng)
+                g = GenericGraph(SimpleGraph(nvg, neg; rng=rng))
                 z = spfa_shortest_paths(g, 1)
                 y = dijkstra_shortest_paths(g, 1)
                 @test isapprox(z, y.dists)
@@ -90,7 +90,7 @@
                 rng = StableRNG(seed)
                 nvg = Int(ceil(250 * rand(rng)))
                 neg = Int(floor((nvg * (nvg - 1) / 2) * rand(rng)))
-                g = SimpleDiGraph(nvg, neg; rng=rng)
+                g = GenericDiGraph(SimpleDiGraph(nvg, neg; rng=rng))
                 z = spfa_shortest_paths(g, 1)
                 y = dijkstra_shortest_paths(g, 1)
                 @test isapprox(z, y.dists)
@@ -99,42 +99,42 @@
     end
 
     @testset "Different types of graph" begin
-        G = complete_graph(9)
+        G = GenericGraph(complete_graph(9))
         z = spfa_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z, y.dists)
 
-        G = complete_digraph(9)
+        G = GenericDiGraph(complete_digraph(9))
         z = spfa_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z, y.dists)
 
-        G = cycle_graph(9)
+        G = GenericGraph(cycle_graph(9))
         z = spfa_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z, y.dists)
 
-        G = cycle_digraph(9)
+        G = GenericDiGraph(cycle_digraph(9))
         z = spfa_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z, y.dists)
 
-        G = star_graph(9)
+        G = GenericGraph(star_graph(9))
         z = spfa_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z, y.dists)
 
-        G = wheel_graph(9)
+        G = GenericGraph(wheel_graph(9))
         z = spfa_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z, y.dists)
 
-        G = roach_graph(9)
+        G = GenericGraph(roach_graph(9))
         z = spfa_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z, y.dists)
 
-        G = clique_graph(5, 19)
+        G = GenericGraph(clique_graph(5, 19))
         z = spfa_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z, y.dists)
@@ -164,9 +164,10 @@
                 :truncatedtetrahedron,
                 :truncatedtetrahedron_dir,
             ]
-                G = smallgraph(s)
-                z = spfa_shortest_paths(G, 1)
-                y = dijkstra_shortest_paths(G, 1)
+                GS = smallgraph(s)
+                GG = is_directed(GS) ? GenericDiGraph(GS) : GenericGraph(GS)
+                z = spfa_shortest_paths(GG, 1)
+                y = dijkstra_shortest_paths(GG, 1)
                 @test isapprox(z, y.dists)
             end
         end
@@ -179,7 +180,7 @@
         d2 = sparse(
             float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0])
         )
-        for g in testdigraphs(g4)
+        for g in test_generic_graphs(g4)
             y = @inferred(spfa_shortest_paths(g, 2, d1))
             z = @inferred(spfa_shortest_paths(g, 2, d2))
             @test y == z == [Inf, 0, 6, 17, 33]
@@ -198,7 +199,7 @@
     @testset "Negative Cycle" begin
         # Negative Cycle 1
         gx = complete_graph(3)
-        for g in testgraphs(gx)
+        for g in test_generic_graphs(gx)
             d = [1 -3 1; -3 1 1; 1 1 1]
             @test_throws Graphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
             @test has_negative_edge_cycle_spfa(g, d)
@@ -211,7 +212,7 @@
         # Negative cycle of length 3 in graph of diameter 4
         gx = complete_graph(4)
         d = [1 -1 1 1; 1 1 1 -1; 1 1 1 1; 1 1 1 1]
-        for g in testgraphs(gx)
+        for g in test_generic_graphs(gx)
             @test_throws Graphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
             @test has_negative_edge_cycle_spfa(g, d)
         end

--- a/test/shortestpaths/yen.jl
+++ b/test/shortestpaths/yen.jl
@@ -1,3 +1,5 @@
+# TODO yen_k_shortest_paths does not wort for GenericGraph yet
+
 @testset "Yen" begin
     g4 = path_digraph(5)
     d1 = float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0])


### PR DESCRIPTION
This PR makes the tests for the shortestpath algorithm use `GenericGraph`

The function in `src/shortestpaths/yen.jl` does currently not work with GenericGraph yet. Also `a_star` only kind of works with `GenericGraph` as this function by default takes `edgetype(g)` as an argument and then tries to use that type as an edge constructor. This does work for `GenericEdge` though. So I doubled some tests - some are run with `SimpleGraph` and `SimpleDiGraph` and some are run with `GenericGraph` and `GenericDiGraph`, but the default edgetype is replaced by `SimpleEdge`.

In addition, this PR fixes a bug where the `has_negative_edge_cycle` might not only fail on a generic graph, but return an incorrect result, as the `MethodError` exception was silently caught and ignored.