### PR TITLE
Use GenericGraph for testing spanningtrees algorithms

### DIFF
--- a/test/spanningtrees/boruvka.jl
+++ b/test/spanningtrees/boruvka.jl
@@ -14,17 +14,19 @@
     max_vec_mst = Vector{Edge}([Edge(1, 4), Edge(2, 4), Edge(1, 3)])
     cost_max_vec_mst = sum(distmx[src(e), dst(e)] for e in max_vec_mst)
 
-    for g in testgraphs(g4)
+    for g in test_generic_graphs(g4)
         # Testing Boruvka's algorithm
         res1 = boruvka_mst(g, distmx)
-        g1t = SimpleGraph(res1.mst)
+        edges1 = [Edge(src(e), dst(e)) for e in res1.mst]
+        g1t = GenericGraph(SimpleGraph(edges1))
         @test res1.weight == cost_mst
         # acyclic graphs have n - c edges
         @test nv(g1t) - length(connected_components(g1t)) == ne(g1t)
         @test nv(g1t) == nv(g)
 
         res2 = boruvka_mst(g, distmx; minimize=false)
-        g2t = SimpleGraph(res2.mst)
+        edges2 = [Edge(src(e), dst(e)) for e in res2.mst]
+        g2t = GenericGraph(SimpleGraph(edges2))
         @test res2.weight == cost_max_vec_mst
         @test nv(g2t) - length(connected_components(g2t)) == ne(g2t)
         @test nv(g2t) == nv(g)
@@ -53,15 +55,17 @@
     ])
     weight_max_vec2 = sum(distmx_sec[src(e), dst(e)] for e in max_vec2)
 
-    for g in testgraphs(gx)
+    for g in test_generic_graphs(gx)
         res3 = boruvka_mst(g, distmx_sec)
-        g3t = SimpleGraph(res3.mst)
+        edges3 = [Edge(src(e), dst(e)) for e in res3.mst]
+        g3t = GenericGraph(SimpleGraph(edges3))
         @test res3.weight == weight_vec2
         @test nv(g3t) - length(connected_components(g3t)) == ne(g3t)
         @test nv(g3t) == nv(gx)
 
         res4 = boruvka_mst(g, distmx_sec; minimize=false)
-        g4t = SimpleGraph(res4.mst)
+        edges4 = [Edge(src(e), dst(e)) for e in res4.mst]
+        g4t = GenericGraph(SimpleGraph(edges4))
         @test res4.weight == weight_max_vec2
         @test nv(g4t) - length(connected_components(g4t)) == ne(g4t)
         @test nv(g4t) == nv(gx)
@@ -114,15 +118,17 @@
     ])
     weight_max_vec3 = sum(distmx_third[src(e), dst(e)] for e in max_vec3)
 
-    for g in testgraphs(gd)
+    for g in test_generic_graphs(gd)
         res5 = boruvka_mst(g, distmx_third)
-        g5t = SimpleGraph(res5.mst)
+        edges5 = [Edge(src(e), dst(e)) for e in res5.mst]
+        g5t = GenericGraph(SimpleGraph(edges5))
         @test res5.weight == weight_vec3
         @test nv(g5t) - length(connected_components(g5t)) == ne(g5t)
         @test nv(g5t) == nv(gd)
 
         res6 = boruvka_mst(g, distmx_third; minimize=false)
-        g6t = SimpleGraph(res6.mst)
+        edges6 = [Edge(src(e), dst(e)) for e in res6.mst]
+        g6t = GenericGraph(SimpleGraph(edges6))
         @test res6.weight == weight_max_vec3
         @test nv(g6t) - length(connected_components(g6t)) == ne(g6t)
         @test nv(g6t) == nv(gd)

--- a/test/spanningtrees/kruskal.jl
+++ b/test/spanningtrees/kruskal.jl
@@ -10,11 +10,14 @@
 
     vec_mst = Vector{Edge}([Edge(1, 2), Edge(3, 4), Edge(2, 3)])
     max_vec_mst = Vector{Edge}([Edge(2, 4), Edge(1, 4), Edge(1, 3)])
-    for g in testgraphs(g4)
+    for g in test_generic_graphs(g4)
         # Testing Kruskal's algorithm
         mst = @inferred(kruskal_mst(g, distmx))
-        @test mst == vec_mst
-        @test @inferred(kruskal_mst(g, distmx, minimize=false)) == max_vec_mst
+        max_mst = @inferred(kruskal_mst(g, distmx, minimize=false))
+        # GenericEdge currently does not implement any comparison operators
+        # so instead we compare tuples of source and target vertices
+        @test sort([(src(e), dst(e)) for e in mst]) == sort([(src(e), dst(e)) for e in vec_mst])
+        @test sort([(src(e), dst(e)) for e in max_mst]) == sort([(src(e), dst(e)) for e in max_vec_mst])
     end
     # second test
     distmx_sec = [
@@ -35,9 +38,10 @@
     max_vec2 = Vector{Edge}([
         Edge(5, 7), Edge(1, 7), Edge(4, 7), Edge(3, 7), Edge(5, 8), Edge(2, 3), Edge(5, 6)
     ])
-    for g in testgraphs(gx)
+    for g in test_generic_graphs(gx)
         mst2 = @inferred(kruskal_mst(g, distmx_sec))
-        @test mst2 == vec2
-        @test @inferred(kruskal_mst(g, distmx_sec, minimize=false)) == max_vec2
+        max_mst2 = @inferred(kruskal_mst(g, distmx_sec, minimize=false))
+        @test sort([(src(e), dst(e)) for e in mst2]) == sort([(src(e), dst(e)) for e in vec2])
+        @test sort([(src(e), dst(e)) for e in max_mst2]) == sort([(src(e), dst(e)) for e in max_vec2])
     end
 end

--- a/test/spanningtrees/prim.jl
+++ b/test/spanningtrees/prim.jl
@@ -9,7 +9,7 @@
     ]
 
     vec_mst = Vector{Edge}([Edge(1, 2), Edge(2, 3), Edge(3, 4)])
-    for g in testgraphs(g4)
+    for g in test_generic_graphs(g4)
         # Testing Prim's algorithm
         mst = @inferred(prim_mst(g, distmx))
         @test mst == vec_mst
@@ -31,7 +31,7 @@
         Edge(8, 2), Edge(1, 3), Edge(3, 4), Edge(6, 5), Edge(8, 6), Edge(3, 7), Edge(1, 8)
     ])
     gx = SimpleGraph(distmx_sec)
-    for g in testgraphs(gx)
+    for g in test_generic_graphs(gx)
         mst2 = @inferred(prim_mst(g, distmx_sec))
         @test mst2 == vec2
     end


### PR DESCRIPTION
This PR makes the tests for the spanningtrees algorithms use `GenericGraph`