### PR TITLE
Tests for various files with generic graph

### DIFF
--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -8,7 +8,7 @@ module Test
 
 using Graphs
 
-export GenericEdge, GenericGraph, GenericDiGraph
+export GenericEdge, GenericGraph, GenericDiGraph, generic_graph
 
 """
     GenericEdge <: Graphs.AbstractEdge
@@ -44,6 +44,16 @@ A directed graph type that can  be used to tests functions that relay on the Gra
 """
 struct GenericDiGraph{T} <: Graphs.AbstractGraph{T}
     g::SimpleDiGraph{T}
+end
+
+"""
+    generic_graph(g::Union{SimpleGraph, SimpleDiGraph})
+
+Return either a GenericGraph or GenericDiGraph that wraps a copy of g.
+"""
+function generic_graph(g::Union{SimpleGraph, SimpleDiGraph})
+    g = copy(g)
+    return is_directed(g) ? GenericDiGraph(g) : GenericGraph(g)
 end
 
 Graphs.is_directed(::Type{<:GenericGraph}) = false

--- a/src/degeneracy.jl
+++ b/src/degeneracy.jl
@@ -324,6 +324,10 @@ Int64[]
 ```
 """
 function k_corona(g::AbstractGraph, k; corenum=core_number(g))
+
+    # TODO k_corona does not correctly work for all AbstractGraph as
+    # it relies on induced_subgraph, which does not work on any AbstractGraph
+
     kcore = k_core(g, k)
     kcoreg = g[kcore]
     kcoredeg = degree(kcoreg)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,3 +1,6 @@
+# TODO most of the operators here do not work with any AbstractGraph yet
+# as they require cloning and modifying graphs.
+
 """
     complement(g)
 
@@ -402,25 +405,16 @@ end
 # """Provides multiplication of a graph `g` by a vector `v` such that spectral
 # graph functions in [GraphMatrices.jl](https://github.com/jpfairbanks/GraphMatrices.jl) can utilize Graphs natively.
 # """
-function *(g::Graph, v::Vector{T}) where {T<:Real}
+function *(g::AbstractGraph, v::Vector{T}) where {T<:Real}
     length(v) == nv(g) || throw(ArgumentError("Vector size must equal number of vertices"))
     y = zeros(T, nv(g))
     for e in edges(g)
         i = src(e)
         j = dst(e)
         y[i] += v[j]
-        y[j] += v[i]
-    end
-    return y
-end
-
-function *(g::DiGraph, v::Vector{T}) where {T<:Real}
-    length(v) == nv(g) || throw(ArgumentError("Vector size must equal number of vertices"))
-    y = zeros(T, nv(g))
-    for e in edges(g)
-        i = src(e)
-        j = dst(e)
-        y[i] += v[j]
+        if !is_directed(g)
+            y[j] += v[i]
+        end
     end
     return y
 end
@@ -481,7 +475,7 @@ julia> size(g, 3)
 1
 ```
 """
-size(g::Graph, dim::Int) = (dim == 1 || dim == 2) ? nv(g) : 1
+size(g::AbstractGraph, dim::Int) = (dim == 1 || dim == 2) ? nv(g) : 1
 
 """
     sum(g)

--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -55,7 +55,11 @@ function _bfs_parents(g::AbstractGraph{T}, source, neighborfn::Function) where {
     end
     while !isempty(cur_level)
         @inbounds for v in cur_level
-            @inbounds @simd for i in neighborfn(g, v)
+            # TODO we previously used @simd on the loop below, but this would fail
+            # if the result of neighorfn(g, v) would not implement firstindex
+            # If @simd really has a performance advantage, then maybe we make
+            # two different cases here.
+            @inbounds for i in neighborfn(g, v)
                 if !visited[i]
                     push!(next_level, i)
                     parents[i] = v

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -7,7 +7,7 @@
     add_edge!(gx, 8, 9)
     add_edge!(gx, 10, 9)
 
-    for g in testgraphs(gx)
+    for g in test_generic_graphs(gx)
         @test @inferred(!is_connected(g))
         cc = @inferred(connected_components(g))
         label = zeros(eltype(g), nv(g))
@@ -20,18 +20,18 @@
         @test cclab[8] == [8, 9, 10]
         @test length(cc) >= 3 && sort(cc[3]) == [8, 9, 10]
     end
-    for g in testgraphs(g6)
+    for g in test_generic_graphs(g6)
         @test @inferred(is_connected(g))
     end
 
     g10 = SimpleDiGraph(4)
     add_edge!(g10, 1, 3)
     add_edge!(g10, 2, 4)
-    for g in testdigraphs(g10)
+    for g in test_generic_graphs(g10)
         @test @inferred(is_bipartite(g))
     end
     add_edge!(g10, 1, 4)
-    for g in testdigraphs(g10)
+    for g in test_generic_graphs(g10)
         @test @inferred(is_bipartite(g))
     end
 
@@ -45,7 +45,7 @@
             end
             if !has_edge(g, i, j)
                 add_edge!(g, i, j)
-                @test @inferred(is_bipartite(g))
+                @test @inferred(is_bipartite(GenericDiGraph(g)))
             end
         end
     end
@@ -66,7 +66,7 @@
     add_edge!(h, 7, 6)
     add_edge!(h, 8, 4)
     add_edge!(h, 8, 7)
-    for g in testdigraphs(h)
+    for g in test_generic_graphs(h)
         @test @inferred(is_weakly_connected(g))
         scc = @inferred(strongly_connected_components(g))
         scc_k = @inferred(strongly_connected_components_kosaraju(g))
@@ -77,15 +77,27 @@
         @test length(wcc) == 1 && length(wcc[1]) == nv(g)
     end
 
-    function scc_ok(graph)
+    function scc_ok(graph::GenericDiGraph)
         # Check that all SCC really are strongly connected
+
+        # TODO it might be better if we did not have to unwrap the GenericDiGraph
+        # (and we somehow might prevent this in the future) but currently the methods
+        # used in this utility test function do not work with GenericDiGraph yet.
+        graph = graph.g
+
         scc = @inferred(strongly_connected_components(graph))
         scc_as_subgraphs = map(i -> graph[i], scc)
         return all(is_strongly_connected, scc_as_subgraphs)
     end
 
-    function scc_k_ok(graph)
+    function scc_k_ok(graph::GenericDiGraph)
         # Check that all SCC really are strongly connected
+
+        # TODO it might be better if we did not have to unwrap the GenericDiGraph
+        # (and we somehow might prevent this in the future) but currently the methods
+        # used in this utility test function do not work with GenericDiGraph yet.
+        graph = graph.g
+
         scc_k = @inferred(strongly_connected_components_kosaraju(graph))
         scc_k_as_subgraphs = map(i -> graph[i], scc_k)
         return all(is_strongly_connected, scc_k_as_subgraphs)
@@ -97,7 +109,7 @@
     add_edge!(h, 4, 2)
     add_edge!(h, 2, 3)
     add_edge!(h, 1, 3)
-    for g in testdigraphs(h)
+    for g in test_generic_graphs(h)
         @test scc_ok(g)
         @test scc_k_ok(g)
     end
@@ -107,14 +119,14 @@
     add_edge!(h2, 2, 4)
     add_edge!(h2, 4, 3)
     add_edge!(h2, 1, 3)
-    for g in testdigraphs(h2)
+    for g in test_generic_graphs(h2)
         @test scc_ok(g)
         @test scc_k_ok(g)
     end
 
     # Test case for empty graph
     h = SimpleDiGraph(0)
-    for g in testdigraphs(h)
+    for g in test_generic_graphs(h)
         scc = @inferred(strongly_connected_components(g))
         scc_k = @inferred(strongly_connected_components_kosaraju(g))
         @test length(scc) == 0
@@ -123,7 +135,7 @@
 
     # Test case for graph with one vertex
     h = SimpleDiGraph(1)
-    for g in testdigraphs(h)
+    for g in test_generic_graphs(h)
         scc = @inferred(strongly_connected_components(g))
         scc_k = @inferred(strongly_connected_components_kosaraju(g))
         @test length(scc) == 1 && scc[1] == [1]
@@ -139,7 +151,7 @@
     add_edge!(h, 2, 3)
     add_edge!(h, 2, 1)
 
-    for g in testdigraphs(h)
+    for g in test_generic_graphs(h)
         scc = @inferred(strongly_connected_components(g))
         scc_k = @inferred(strongly_connected_components_kosaraju(g))
         @test length(scc) == 2
@@ -159,7 +171,7 @@
     add_edge!(h, 3, 5)
     add_edge!(h, 5, 6)
     add_edge!(h, 6, 4)
-    for g in testdigraphs(h)
+    for g in test_generic_graphs(h)
         scc = @inferred(strongly_connected_components(g))
         scc_k = @inferred(strongly_connected_components_kosaraju(g))
         @test length(scc) == 1 && sort(scc[1]) == [1:6;]
@@ -171,7 +183,7 @@
     add_edge!(h, 2, 3)
     add_edge!(h, 3, 1)
     add_edge!(h, 4, 1)
-    for g in testdigraphs(h)
+    for g in test_generic_graphs(h)
         scc = @inferred(strongly_connected_components(g))
         scc_k = @inferred(strongly_connected_components_kosaraju(g))
         @test length(scc) == 2 && sort(scc[1]) == [1:3;] && sort(scc[2]) == [4]
@@ -200,7 +212,7 @@
     add_edge!(h, 11, 12)
     add_edge!(h, 12, 10)
 
-    for g in testdigraphs(h)
+    for g in test_generic_graphs(h)
         scc = @inferred(strongly_connected_components(g))
         scc_k = @inferred(strongly_connected_components_kosaraju(g))
         @test length(scc) == 4
@@ -224,37 +236,40 @@
     fig1[[3, 4, 9, 10, 11, 13, 18, 19, 22, 24]] = [
         0.5, 0.4, 0.1, 1.0, 1.0, 0.2, 0.3, 0.2, 1.0, 0.3
     ]
-    fig1 = SimpleDiGraph(fig1)
+    fig1 = GenericDiGraph(SimpleDiGraph(fig1))
     scc_fig1 = Vector[[2, 5], [1, 3, 4]]
 
     # figure 2 example
     fig2 = spzeros(5, 5)
     fig2[[3, 10, 11, 13, 14, 17, 18, 19, 22]] .= 1
-    fig2 = SimpleDiGraph(fig2)
+    fig2 = GenericDiGraph(SimpleDiGraph(fig2))
 
     # figure 3 example
     fig3 = spzeros(8, 8)
     fig3[[
         1, 7, 9, 13, 14, 15, 18, 20, 23, 27, 28, 31, 33, 34, 37, 45, 46, 49, 57, 63, 64
     ]] .= 1
-    fig3 = SimpleDiGraph(fig3)
+    fig3 = GenericDiGraph(SimpleDiGraph(fig3))
     scc_fig3 = Vector[[3, 4], [2, 5, 6], [8], [1, 7]]
     fig3_cond = SimpleDiGraph(4)
     add_edge!(fig3_cond, 4, 3)
     add_edge!(fig3_cond, 2, 1)
     add_edge!(fig3_cond, 4, 1)
     add_edge!(fig3_cond, 4, 2)
+    fig3_cond
 
     # construct a n-number edge ring graph (period = n)
     n = 10
     n_ring = cycle_digraph(n)
     n_ring_shortcut = copy(n_ring)
     add_edge!(n_ring_shortcut, 1, 4)
+    n_ring = GenericDiGraph(n_ring)
+    n_ring_shortcut = GenericDiGraph(n_ring_shortcut)
 
     # figure 8 example
     fig8 = spzeros(6, 6)
     fig8[[2, 10, 13, 21, 24, 27, 35]] .= 1
-    fig8 = SimpleDiGraph(fig8)
+    fig8 = GenericDiGraph(SimpleDiGraph(fig8))
 
     @test Set(@inferred(strongly_connected_components(fig1))) == Set(scc_fig1)
     @test Set(@inferred(strongly_connected_components(fig3))) == Set(scc_fig3)
@@ -262,6 +277,9 @@
     @test @inferred(period(n_ring)) == n
     @test @inferred(period(n_ring_shortcut)) == 2
 
+    # TODO condensation currently returns a SimpleDiGraph, even if the input graph
+    # is a GenericDiGraph, so we compare with a SimpleDiGraph in this test,
+    # but one should think, if the condensation should not also be a GenericDiGraph
     @test @inferred(condensation(fig3)) == fig3_cond
 
     @test @inferred(attracting_components(fig1)) == Vector[[2, 5]]
@@ -270,7 +288,7 @@
     g10dists = ones(10, 10)
     g10dists[1, 2] = 10.0
     g10 = star_graph(10)
-    for g in testgraphs(g10)
+    for g in test_generic_graphs(g10)
         @test @inferred(neighborhood_dists(g, 1, 0)) == [(1, 0)]
         @test length(@inferred(neighborhood(g, 1, 1))) == 10
         @test length(@inferred(neighborhood(g, 1, 1, g10dists))) == 9
@@ -280,8 +298,8 @@
         @test length(@inferred(neighborhood(g, 2, -1))) == 0
     end
     g10 = star_digraph(10)
-    for g in testdigraphs(g10)
-        @test @inferred(neighborhood_dists(g10, 1, 0, dir=:out)) == [(1, 0)]
+    for g in test_generic_graphs(g10)
+        @test @inferred(neighborhood_dists(g, 1, 0, dir=:out)) == [(1, 0)]
         @test length(@inferred(neighborhood(g, 1, 1, dir=:out))) == 10
         @test length(@inferred(neighborhood(g, 1, 1, g10dists, dir=:out))) == 9
         @test length(@inferred(neighborhood(g, 2, 1, dir=:out))) == 1
@@ -301,7 +319,7 @@
     ##@test !@inferred(isgraphical([2]))
 
     # Test simple digraphicality
-    sdg = SimpleDiGraph(10, 90)
+    sdg = GenericDiGraph(SimpleDiGraph(10, 90))
     @test @inferred(isdigraphical(indegree(sdg), outdegree(sdg)))
     @test !@inferred(isdigraphical([1, 1, 1], [1, 1, 0]))
     @test @inferred(isdigraphical(Integer[], Integer[]))
@@ -314,14 +332,14 @@
 
     # 1116
     gc = cycle_graph(4)
-    for g in testgraphs(gc)
+    for g in test_generic_graphs(gc)
         z = @inferred(neighborhood(g, 3, 3))
         @test (z == [3, 2, 4, 1] || z == [3, 4, 2, 1])
     end
 
     gd = SimpleDiGraph([0 1 1 0; 0 0 0 1; 0 0 0 1; 0 0 0 0])
     add_edge!(gd, 1, 4)
-    for g in testdigraphs(gd)
+    for g in test_generic_graphs(gd)
         z = @inferred(neighborhood_dists(g, 1, 4))
         @test (4, 1) ∈ z
         @test (4, 2) ∉ z

--- a/test/core.jl
+++ b/test/core.jl
@@ -6,6 +6,7 @@
     @test @inferred(is_ordered(e2))
     @test @inferred(!is_ordered(reverse(e3)))
 
+    # TODO we cannot test add_vertices! with generic graphs
     @testset "add_vertices!" begin
         gx = SimpleGraph(10)
         gdx = SimpleDiGraph(10)
@@ -19,7 +20,7 @@
     g5w = wheel_graph(5)
     g5wd = wheel_digraph(5)
     @testset "degree functions" begin
-        @testset "$g" for g in testgraphs(g5w)
+        @testset "$(typeof(g))" for g in test_generic_graphs(g5w)
             @test @inferred(indegree(g, 1)) == @inferred(outdegree(g, 1)) == 4
             @test degree(g, 1) == 4 # explicit codecov
             @test @inferred(indegree(g)) ==
@@ -34,7 +35,7 @@
             z3 = @inferred(degree_histogram(g, outdegree))
             @test z1 == z2 == z3 == Dict(4 => 1, 3 => 4)
         end
-        @testset "$g" for g in testdigraphs(g5wd)
+        @testset "$(typeof(g))" for g in test_generic_graphs(g5wd)
             @test @inferred(indegree(g, 2)) == 2
             @test @inferred(outdegree(g, 2)) == 1
             @test @inferred(degree(g, 2)) == 3
@@ -56,42 +57,42 @@
     end
 
     @testset "weights" begin
-        @testset "$g" for g in testgraphs(g5w, g5wd)
+        @testset "$(typeof(g))" for g in test_generic_graphs(g5w, g5wd)
             @test @inferred(weights(g)) == Graphs.DefaultDistance(nv(g))
         end
     end
 
     @testset "neighbor functions" begin
-        @testset "$g" for g in testgraphs(g5w)
-            @test @inferred(neighbors(g, 2)) == [1, 3, 5]
-            @test @inferred(all_neighbors(g, 2)) == [1, 3, 5]
+        @testset "$(typeof(g))" for g in test_generic_graphs(g5w)
+            @test collect(@inferred(neighbors(g, 2))) == [1, 3, 5]
+            @test collect(@inferred(all_neighbors(g, 2))) == [1, 3, 5]
             @test @inferred(common_neighbors(g, 1, 5)) == [2, 4]
         end
-        @testset "$g" for g in testgraphs(g5wd)
-            @test @inferred(neighbors(g, 2)) == [3]
+        @testset "$(typeof(g))" for g in test_generic_graphs(g5wd)
+            @test collect(@inferred(neighbors(g, 2))) == [3]
             @test Set(@inferred(all_neighbors(g, 2))) == Set([1, 3, 5])
             @test @inferred(common_neighbors(g, 1, 5)) == [2]
         end
     end
 
     @testset "self loops" begin
-        @testset "$g" for g in testgraphs(g5w, g5wd)
+        @testset "$(typeof(g))" for g in testgraphs(g5w, g5wd)
             gsl = copy(g)
             add_edge!(gsl, 3, 3)
             add_edge!(gsl, 2, 2)
-            @test @inferred(!has_self_loops(g))
-            @test @inferred(has_self_loops(gsl))
-            @test @inferred(num_self_loops(g)) == 0
-            @test @inferred(num_self_loops(gsl)) == 2
+            @test @inferred(!has_self_loops(generic_graph(g)))
+            @test @inferred(has_self_loops(generic_graph(gsl)))
+            @test @inferred(num_self_loops(generic_graph(g))) == 0
+            @test @inferred(num_self_loops(generic_graph(gsl))) == 2
         end
     end
 
     @testset "density" begin
-        @testset "$g" for g in testgraphs(g5w)
+        @testset "$(typeof(g))" for g in test_generic_graphs(g5w)
             @test @inferred(density(g)) == 0.8
         end
 
-        @testset "$g" for g in testdigraphs(g5wd)
+        @testset "$(typeof(g))" for g in test_generic_graphs(g5wd)
             @test @inferred(density(g)) == 0.4
         end
     end

--- a/test/degeneracy.jl
+++ b/test/degeneracy.jl
@@ -1,7 +1,7 @@
 @testset "Decomposition" begin
     d = loadgraph(joinpath(testdir, "testdata", "graph-decomposition.jgz"))
 
-    @testset "$g" for g in testgraphs(d)
+    @testset "$(typeof(g))" for g in test_generic_graphs(d)
         corenum = @inferred(core_number(g))
         @test corenum == [3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 0]
 
@@ -23,17 +23,26 @@
             @test @inferred(k_crust(g, 4, corenum=corenum)) == [1:21;]
         end
 
-        @testset "k-corona" begin
-            @test @inferred(k_corona(g, 1)) == k_corona(g, 1; corenum=corenum) == [17:20;]
-            @test @inferred(k_corona(g, 2)) == [10, 12, 13, 14, 15, 16]
-        end
+    end
 
-        @testset "errors" begin
-            add_edge!(g, 1, 1)
-            @test_throws ArgumentError k_core(g)
-            @test_throws ArgumentError k_shell(g)
-            @test_throws ArgumentError k_crust(g)
-            @test_throws ArgumentError k_corona(g, 1)
-        end
+    # TODO k_corona does not work yet with generic graphs
+    @testset "k-corona $(typeof(g))" for g in testgraphs(d)
+        corenum = [3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 0]
+
+        @test @inferred(k_corona(g, 1)) == k_corona(g, 1; corenum=corenum) == [17:20;]
+        @test @inferred(k_corona(g, 2)) == [10, 12, 13, 14, 15, 16]
+    end
+
+    d_loop = copy(d)
+    add_edge!(d_loop, 1, 1)
+    @testset "errors $(typeof(g))" for g in test_generic_graphs(d_loop)
+        @test_throws ArgumentError k_core(g)
+        @test_throws ArgumentError k_shell(g)
+        @test_throws ArgumentError k_crust(g)
+    end
+
+    # TODO k_corona does not work yet with generic graphs
+    @testset "k-corona errors $(typeof(g))" for g in testgraphs(d_loop)
+        @test_throws ArgumentError k_corona(g, 1)
     end
 end

--- a/test/distance.jl
+++ b/test/distance.jl
@@ -7,7 +7,7 @@
     distmx1 = [Inf 2.0 Inf; 2.0 Inf 4.2; Inf 4.2 Inf]
     distmx2 = [Inf 2.0 Inf; 3.2 Inf 4.2; 5.5 6.1 Inf]
 
-    @testset "$g" for g in testgraphs(a1)
+    @testset "$(typeof(g))" for g in test_generic_graphs(a1)
         z = @inferred(eccentricity(g, distmx1))
         @testset "eccentricity" begin
             @test z == [6.2, 4.2, 6.2]
@@ -26,7 +26,7 @@
         end
     end
 
-    @testset "$g" for g in testgraphs(a2)
+    @testset "$(typeof(g))" for g in test_generic_graphs(a2)
         z = @inferred(eccentricity(g, distmx2))
         @testset "eccentricity" begin
             @test z == [6.2, 4.2, 6.1]
@@ -58,14 +58,14 @@
 
     @testset "warnings and errors" begin
         # ensures that eccentricity only throws an error if there is more than one component
-        g1 = SimpleGraph(2)
+        g1 = GenericGraph(SimpleGraph(2))
         @test_logs (:warn, "Infinite path length detected for vertex 1") match_mode = :any eccentricity(
             g1
         )
         @test_logs (:warn, "Infinite path length detected for vertex 2") match_mode = :any eccentricity(
             g1
         )
-        g2 = path_graph(2)
+        g2 = GenericGraph(path_graph(2))
         @test_logs eccentricity(g2)
     end
 end

--- a/test/edit_distance.jl
+++ b/test/edit_distance.jl
@@ -14,7 +14,7 @@
     edge_delete_cost = e -> 5.0
     edge_subst_cost = (e1, e2) -> 6.0
 
-    @testset "undirected edit_distance" for G1 in testgraphs(g1), G2 in testgraphs(g2)
+    @testset "undirected edit_distance" for G1 in test_generic_graphs(g1), G2 in test_generic_graphs(g2)
         d, λ = @inferred(edit_distance(G1, G2))
         @test d == 2.0
         d, λ = @inferred(
@@ -44,7 +44,7 @@
         add_edge!(g2, e)
     end
 
-    @testset "directed edit_distance" for G1 in testgraphs(g1), G2 in testgraphs(g2)
+    @testset "directed edit_distance" for G1 in test_generic_graphs(g1), G2 in test_generic_graphs(g2)
         d, λ = @inferred(edit_distance(G1, G2))
         @test d == 4.0
     end

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -1,3 +1,7 @@
+# TODO most of the tests here do not work with generic graphs yet
+# as the require the ability to copy or modify graphs, which is not provided
+# by the AbstractGraph interface
+
 @testset "Operators" begin
     rng = StableRNG(1)
 
@@ -176,7 +180,7 @@
     end
 
     px = path_graph(10)
-    @testset "Matrix operations: $p" for p in testgraphs(px)
+    @testset "Matrix operations: $(typeof(p))" for p in test_generic_graphs(px)
         x = @inferred(p * ones(10))
         @test x[1] == 1.0 && all(x[2:(end - 1)] .== 2.0) && x[end] == 1.0
         @test size(p) == (10, 10)
@@ -195,7 +199,7 @@
     add_edge!(gx, 2, 3)
     add_edge!(gx, 1, 3)
     add_edge!(gx, 3, 4)
-    @testset "Matrix operations: $g" for g in testdigraphs(gx)
+    @testset "Matrix operations: $(typeof(g))" for g in test_generic_graphs(gx)
         @test @inferred(g * ones(nv(g))) == [2.0, 1.0, 1.0, 0.0]
         @test sum(g, 1) == [0, 1, 2, 1]
         @test sum(g, 2) == [2, 1, 1, 0]
@@ -208,7 +212,7 @@
     add_edge!(gx, 2, 1)
     add_edge!(gx, 1, 3)
     add_edge!(gx, 3, 1)
-    @testset "Matrix operations: $g" for g in testdigraphs(gx)
+    @testset "Matrix operations: $(typeof(g))" for g in test_generic_graphs(gx)
         @test @inferred(issymmetric(g))
     end
 
@@ -332,7 +336,7 @@
         @test @inferred(ndims(g)) == 2
     end
 
-    @testset "Length: $g" for g in testgraphs(SimpleGraph(100))
+    @testset "Length: $(typeof(g))" for g in test_generic_graphs(SimpleGraph(100))
         @test length(g) == 10000
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,6 +79,8 @@ function test_generic_graphs(g; eltypes=[UInt8, Int16], skip_if_too_large::Bool=
     return result
 end
 
+test_generic_graphs(gs...; kwargs...) = vcat((test_generic_graphs(g; kwargs...) for g in gs)...)
+
 test_large_generic_graphs(g; skip_if_too_large::Bool=false) = test_generic_graphs(g; eltypes=[UInt16, Int32], skip_if_too_large=skip_if_too_large)
 
 


### PR DESCRIPTION
This PR changes the tests to use generic graphs for various files that were not grouped together like others.

There where no larger changes necessary to make the tests work, but a small change was necessary for `bfs_parents` and some type annotations in `operators.jl` had to be changed so that they would accept abstract graphs.