### PR TITLE
Add Hopcroft-Karp matching algorithm

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -60,6 +60,7 @@ pages_files = [
         "algorithms/editdist.md",
         "algorithms/independentset.md",
         "algorithms/linalg.md",
+        "algorithms/matching.md",
         "algorithms/shortestpaths.md",
         "algorithms/spanningtrees.md",
         "algorithms/steinertree.md",

--- a/docs/src/algorithms/matching.md
+++ b/docs/src/algorithms/matching.md
@@ -11,5 +11,8 @@ Pages = ["matching.md"]
 ## Full docs
 
 ```@docs
+AbstractMaximumMatchingAlgorithm
+HopcroftKarpAlgorithm
+maximum_cardinality_matching
 hopcroft_karp_matching
 ```

--- a/docs/src/algorithms/matching.md
+++ b/docs/src/algorithms/matching.md
@@ -1,0 +1,15 @@
+# Matchings
+
+_Graphs.jl_ contains functions related to matchings.
+
+## Index
+
+```@index
+Pages = ["matching.md"]
+```
+
+## Full docs
+
+```@docs
+hopcroft_karp_matching
+```

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -422,7 +422,10 @@ export
     independent_set,
 
     # vertexcover
-    vertex_cover
+    vertex_cover,
+
+    # matching
+    hopcroft_karp_matching
 
 """
     Graphs
@@ -538,6 +541,7 @@ include("vertexcover/random_vertex_cover.jl")
 include("Experimental/Experimental.jl")
 include("Parallel/Parallel.jl")
 include("Test/Test.jl")
+include("matching/maximum_matching.jl")
 
 using .LinAlg
 end # module

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -425,7 +425,10 @@ export
     vertex_cover,
 
     # matching
-    hopcroft_karp_matching
+    AbstractMaximumMatchingAlgorithm,
+    HopcroftKarpAlgorithm,
+    hopcroft_karp_matching,
+    maximum_cardinality_matching
 
 """
     Graphs

--- a/src/matching/hopcroft_karp.jl
+++ b/src/matching/hopcroft_karp.jl
@@ -1,5 +1,5 @@
 const UNMATCHED = nothing
-MatchedNodeType{T} = Union{T, typeof(UNMATCHED)}
+MatchedNodeType{T} = Union{T,typeof(UNMATCHED)}
 
 """
 Determine whether an augmenting path exists and mark distances
@@ -8,13 +8,13 @@ so we can compute shortest-length augmenting paths in the DFS.
 function _hk_augmenting_bfs!(
     graph::AbstractGraph{T},
     set1::Vector{T},
-    matching::Dict{T, MatchedNodeType{T}},
-    distance::Dict{MatchedNodeType{T}, Float64},
-)::Bool where {T <: Integer}
+    matching::Dict{T,MatchedNodeType{T}},
+    distance::Dict{MatchedNodeType{T},Float64},
+)::Bool where {T<:Integer}
     # Initialize queue with the unmatched nodes in set1
-    queue = Vector{MatchedNodeType{eltype(graph)}}(
-        [n for n in set1 if matching[n] == UNMATCHED]
-    )
+    queue = Vector{MatchedNodeType{eltype(graph)}}([
+        n for n in set1 if matching[n] == UNMATCHED
+    ])
 
     distance[UNMATCHED] = Inf
     for n in set1
@@ -54,9 +54,9 @@ Compute augmenting paths and update the matching
 function _hk_augmenting_dfs!(
     graph::AbstractGraph{T},
     root::MatchedNodeType{T},
-    matching::Dict{T, MatchedNodeType{T}},
-    distance::Dict{MatchedNodeType{T}, Float64},
-)::Bool where {T <: Integer}
+    matching::Dict{T,MatchedNodeType{T}},
+    distance::Dict{MatchedNodeType{T},Float64},
+)::Bool where {T<:Integer}
     if root != UNMATCHED
         for n in neighbors(graph, root)
             # Traverse edges of the minimum-length alternating path
@@ -105,9 +105,7 @@ this algorithm is particularly effective for sparse bipartite graphs.
 * `ArgumentError`: The provided graph is not bipartite
 
 """
-function hopcroft_karp_matching(
-   graph::AbstractGraph{T}
-)::Dict{T, T} where {T <: Integer}
+function hopcroft_karp_matching(graph::AbstractGraph{T})::Dict{T,T} where {T<:Integer}
     bmap = bipartite_map(graph)
     if length(bmap) != nv(graph)
         throw(ArgumentError("Provided graph is not bipartite"))
@@ -115,10 +113,10 @@ function hopcroft_karp_matching(
     set1 = [n for n in vertices(graph) if bmap[n] == 1]
 
     # Initialize "state" that is modified during the algorithm
-    matching = Dict{eltype(graph), MatchedNodeType{eltype(graph)}}(
+    matching = Dict{eltype(graph),MatchedNodeType{eltype(graph)}}(
         n => UNMATCHED for n in vertices(graph)
     )
-    distance = Dict{MatchedNodeType{eltype(graph)}, Float64}()
+    distance = Dict{MatchedNodeType{eltype(graph)},Float64}()
 
     # BFS to determine whether any augmenting paths exist
     while _hk_augmenting_bfs!(graph, set1, matching, distance)
@@ -133,4 +131,3 @@ function hopcroft_karp_matching(
     matching = Dict(i => j for (i, j) in matching if j != UNMATCHED)
     return matching
 end
-

--- a/src/matching/hopcroft_karp.jl
+++ b/src/matching/hopcroft_karp.jl
@@ -1,0 +1,136 @@
+const UNMATCHED = nothing
+MatchedNodeType{T} = Union{T, typeof(UNMATCHED)}
+
+"""
+Determine whether an augmenting path exists and mark distances
+so we can compute shortest-length augmenting paths in the DFS.
+"""
+function _hk_augmenting_bfs!(
+    graph::AbstractGraph{T},
+    set1::Vector{T},
+    matching::Dict{T, MatchedNodeType{T}},
+    distance::Dict{MatchedNodeType{T}, Float64},
+)::Bool where {T <: Integer}
+    # Initialize queue with the unmatched nodes in set1
+    queue = Vector{MatchedNodeType{eltype(graph)}}(
+        [n for n in set1 if matching[n] == UNMATCHED]
+    )
+
+    distance[UNMATCHED] = Inf
+    for n in set1
+        if matching[n] == UNMATCHED
+            distance[n] = 0.0
+        else
+            distance[n] = Inf
+        end
+    end
+
+    while !isempty(queue)
+        n1 = popfirst!(queue)
+
+        # If n1 is (a) matched or (b) in set1
+        if distance[n1] < Inf && n1 != UNMATCHED
+            for n2 in neighbors(graph, n1)
+                # If n2 has not been encountered
+                if distance[matching[n2]] == Inf
+                    # Give it a distance
+                    distance[matching[n2]] = distance[n1] + 1
+
+                    # Note that n2 could be unmatched
+                    push!(queue, matching[n2])
+                end
+            end
+        end
+    end
+
+    found_augmenting_path = (distance[UNMATCHED] < Inf)
+    # The distance to UNMATCHED is the length of the shortest augmenting path
+    return found_augmenting_path
+end
+
+"""
+Compute augmenting paths and update the matching
+"""
+function _hk_augmenting_dfs!(
+    graph::AbstractGraph{T},
+    root::MatchedNodeType{T},
+    matching::Dict{T, MatchedNodeType{T}},
+    distance::Dict{MatchedNodeType{T}, Float64},
+)::Bool where {T <: Integer}
+    if root != UNMATCHED
+        for n in neighbors(graph, root)
+            # Traverse edges of the minimum-length alternating path
+            if distance[matching[n]] == distance[root] + 1
+                if _hk_augmenting_dfs!(graph, matching[n], matching, distance)
+                    # If the edge is part of an augmenting path, update the
+                    # matching
+                    matching[root] = n
+                    matching[n] = root
+                    return true
+                end
+            end
+        end
+        # If we could not find a matched edge that was part of an augmenting
+        # path, we need to make sure we don't consider this vertex again
+        distance[root] = Inf
+        return false
+    else
+        # Return true to indicate that we are part of an augmenting path
+        return true
+    end
+end
+
+"""
+    hopcroft_karp_matching(graph::AbstractGraph)::Dict
+
+Compute a maximum-cardinality matching of a bipartite graph via the
+[Hopcroft-Karp algorithm](https://en.wikipedia.org/wiki/Hopcroft-Karp_algorithm).
+
+The return type is a dict mapping nodes to nodes. All matched nodes are included
+as keys. For example, if `i` is matched with `j`, `i => j` and `j => i` are both
+included in the returned dict.
+
+### Performance
+
+The algorithms runs in O((m + n)n^0.5), where n is the number of vertices and
+m is the number of edges. As it does not assume the number of edges is O(n^2),
+this algorithm is particularly effective for sparse bipartite graphs.
+
+### Arguments
+
+* `graph`: The bipartite `Graph` for which a maximum matching is computed
+
+### Exceptions
+
+* `ArgumentError`: The provided graph is not bipartite
+
+"""
+function hopcroft_karp_matching(
+   graph::AbstractGraph{T}
+)::Dict{T, T} where {T <: Integer}
+    bmap = bipartite_map(graph)
+    if length(bmap) != nv(graph)
+        throw(ArgumentError("Provided graph is not bipartite"))
+    end
+    set1 = [n for n in vertices(graph) if bmap[n] == 1]
+
+    # Initialize "state" that is modified during the algorithm
+    matching = Dict{eltype(graph), MatchedNodeType{eltype(graph)}}(
+        n => UNMATCHED for n in vertices(graph)
+    )
+    distance = Dict{MatchedNodeType{eltype(graph)}, Float64}()
+
+    # BFS to determine whether any augmenting paths exist
+    while _hk_augmenting_bfs!(graph, set1, matching, distance)
+        for n1 in set1
+            if matching[n1] == UNMATCHED
+                # DFS to update the matching along a minimum-length
+                # augmenting path
+                _hk_augmenting_dfs!(graph, n1, matching, distance)
+            end
+        end
+    end
+    matching = Dict(i => j for (i, j) in matching if j != UNMATCHED)
+    return matching
+end
+

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -73,13 +73,14 @@ function _hk_dfs!(
 end
 
 """
-    hopcroft_karp_matching(graph::Graph, set1::Set)::Dict
+    hopcroft_karp_matching(graph::Graph)::Dict
 
 Compute a maximum-cardinality matching of a bipartite graph via the
 [Hopcroft-Karp algorithm](https://en.wikipedia.org/wiki/Hopcroft-Karp_algorithm).
 
-The return type is a dict mapping nodes in `set1` to other nodes *and* other
-nodes back to their matched nodes in `set`.
+The return type is a dict mapping nodes to nodes. All matched nodes are included
+as keys. For exmaple, if `i` is matched with `j`, `i => j` and `j => i` are both
+included in the returned dict.
 
 ### Performance
 The algorithms runs in O((m + n)n^0.5), where n is the number of vertices and
@@ -90,12 +91,11 @@ this algorithm is particularly effective for sparse bipartite graphs.
 
 * `graph`: The bipartite `Graph` for which a maximum matching is computed
 
-* `set1`: A set of vertices in a bipartition
-
 """
-function hopcroft_karp_matching(graph::Graph, set1::Set)
+function hopcroft_karp_matching(graph::Graph)
+    bmap = bipartite_map(graph)
+    set1 = [n for n in vertices(graph) if bmap[n] == 1]
     matching = Dict(n => UNMATCHED for n in vertices(graph))
-    set1 = [n for n in vertices(graph) if n in set1]
     distance = Dict{Int, Float64}()
     while _hk_augmenting_bfs!(graph, set1, matching, distance)
         for n1 in set1

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -64,14 +64,13 @@ Dict{Int64, Int64} with 6 entries:
 """
 function maximum_cardinality_matching(
     graph::AbstractGraph{T};
-    algorithm::AbstractMaximumMatchingAlgorithm = HopcroftKarpAlgorithm(),
-)::Dict{T, T} where {T <: Integer}
+    algorithm::AbstractMaximumMatchingAlgorithm=HopcroftKarpAlgorithm(),
+)::Dict{T,T} where {T<:Integer}
     return maximum_cardinality_matching(graph, algorithm)
 end
 
 function maximum_cardinality_matching(
-    graph::AbstractGraph{T},
-    algorithm::HopcroftKarpAlgorithm,
-)::Dict{T, T} where {T <: Integer}
+    graph::AbstractGraph{T}, algorithm::HopcroftKarpAlgorithm
+)::Dict{T,T} where {T<:Integer}
     return hopcroft_karp_matching(graph)
 end

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -81,6 +81,11 @@ Compute a maximum-cardinality matching of a bipartite graph via the
 The return type is a dict mapping nodes in `set1` to other nodes *and* other
 nodes back to their matched nodes in `set`.
 
+### Performance
+The algorithms runs in O((m + n)n^0.5), where n is the number of vertices and
+m is the number of edges. As it does not assume the number of edges is O(n^2),
+this algorithm is particularly effective for sparse bipartite graphs.
+
 ### Arguments
 
 * `graph`: The bipartite `Graph` for which a maximum matching is computed

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -21,7 +21,7 @@ Determine whether an augmenting path exists and mark distances
 so we can compute shortest-length augmenting paths in the DFS.
 """
 function _hk_augmenting_bfs!(
-    graph::Graph{T},
+    graph::AbstractGraph{T},
     set1::Vector{T},
     matching::Dict{T, MatchedNodeType{T}},
     distance::Dict{MatchedNodeType{T}, Float64},
@@ -67,7 +67,7 @@ end
 Compute augmenting paths and update the matching
 """
 function _hk_augmenting_dfs!(
-    graph::Graph{T},
+    graph::AbstractGraph{T},
     root::MatchedNodeType{T},
     matching::Dict{T, MatchedNodeType{T}},
     distance::Dict{MatchedNodeType{T}, Float64},
@@ -96,7 +96,7 @@ function _hk_augmenting_dfs!(
 end
 
 """
-    hopcroft_karp_matching(graph::Graph)::Dict
+    hopcroft_karp_matching(graph::AbstractGraph)::Dict
 
 Compute a maximum-cardinality matching of a bipartite graph via the
 [Hopcroft-Karp algorithm](https://en.wikipedia.org/wiki/Hopcroft-Karp_algorithm).
@@ -121,7 +121,7 @@ this algorithm is particularly effective for sparse bipartite graphs.
 
 """
 function hopcroft_karp_matching(
-   graph::Graph{T}
+   graph::AbstractGraph{T}
 )::Dict{T, T} where {T <: Integer}
     bmap = bipartite_map(graph)
     if length(bmap) != nv(graph)
@@ -150,7 +150,7 @@ function hopcroft_karp_matching(
 end
 
 function maximum_cardinality_matching(
-    graph::Graph{T},
+    graph::AbstractGraph{T},
     algorithm::HopcroftKarpAlgorithm,
 )::Dict{T, T} where {T <: Integer}
     return hopcroft_karp_matching(graph)
@@ -158,7 +158,7 @@ end
 
 """
     maximum_cardinality_matching(
-        graph::Graph,
+        graph::AbstractGraph,
         algorithm::AbstractMaximumMatchingAlgorithm,
     )::Dict{Int, Int}
 
@@ -204,7 +204,7 @@ Dict{Int64, Int64} with 6 entries:
 ```
 """
 function maximum_cardinality_matching(
-    graph::Graph{T};
+    graph::AbstractGraph{T};
     algorithm::AbstractMaximumMatchingAlgorithm = HopcroftKarpAlgorithm(),
 )::Dict{T, T} where {T <: Integer}
     return maximum_cardinality_matching(graph, algorithm)

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -94,6 +94,9 @@ this algorithm is particularly effective for sparse bipartite graphs.
 """
 function hopcroft_karp_matching(graph::Graph)
     bmap = bipartite_map(graph)
+    if length(bmap) != nv(graph)
+        throw(ArgumentError("Provided graph is not bipartite"))
+    end
     set1 = [n for n in vertices(graph) if bmap[n] == 1]
     matching = Dict(n => UNMATCHED for n in vertices(graph))
     distance = Dict{Int, Float64}()

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -99,6 +99,24 @@ this algorithm is particularly effective for sparse bipartite graphs.
 
 * `graph`: The bipartite `Graph` for which a maximum matching is computed
 
+### Example
+```jldoctest
+julia> using Graphs
+
+julia> g = complete_bipartite_graph(3, 5)
+{8, 15} undirected simple Int64 graph
+
+julia> # Note that the exact matching we compute here is implementation-dependent
+
+julia> hopcroft_karp_matching(g)
+Dict{Int64, Int64} with 6 entries:
+  5 => 2
+  4 => 1
+  6 => 3
+  2 => 5
+  3 => 6
+  1 => 4
+```
 """
 function hopcroft_karp_matching(graph::Graph)
     bmap = bipartite_map(graph)

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -119,7 +119,9 @@ this algorithm is particularly effective for sparse bipartite graphs.
 * `ArgumentError`: The provided graph is not bipartite
 
 """
-function hopcroft_karp_matching(graph::Graph)::Dict{Int, Int}
+function hopcroft_karp_matching(
+   graph::Graph{T}
+)::Dict{T, T} where {T <: Integer}
     bmap = bipartite_map(graph)
     if length(bmap) != nv(graph)
         throw(ArgumentError("Provided graph is not bipartite"))
@@ -147,9 +149,9 @@ function hopcroft_karp_matching(graph::Graph)::Dict{Int, Int}
 end
 
 function maximum_cardinality_matching(
-    graph::Graph,
+    graph::Graph{T},
     algorithm::HopcroftKarpAlgorithm,
-)::Dict{Int, Int}
+)::Dict{T, T} where {T <: Integer}
     return hopcroft_karp_matching(graph)
 end
 
@@ -201,8 +203,8 @@ Dict{Int64, Int64} with 6 entries:
 ```
 """
 function maximum_cardinality_matching(
-    graph::Graph;
+    graph::Graph{T};
     algorithm::AbstractMaximumMatchingAlgorithm = HopcroftKarpAlgorithm(),
-)::Dict{Int, Int}
+)::Dict{T, T} where {T <: Integer}
     return maximum_cardinality_matching(graph, algorithm)
 end

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -1,4 +1,5 @@
 const UNMATCHED = nothing
+MatchedNodeType{T} = Union{T, typeof(UNMATCHED)}
 
 """
     AbstractMaximumMatchingAlgorithm
@@ -22,11 +23,11 @@ so we can compute shortest-length augmenting paths in the DFS.
 function _hk_augmenting_bfs!(
     graph::Graph{T},
     set1::Vector{T},
-    matching::Dict{T, Union{T, typeof(UNMATCHED)}},
-    distance::Dict{Union{T, typeof(UNMATCHED)}, Float64},
+    matching::Dict{T, MatchedNodeType{T}},
+    distance::Dict{MatchedNodeType{T}, Float64},
 )::Bool where {T <: Integer}
     # Initialize queue with the unmatched nodes in set1
-    queue = Vector{Union{eltype(graph), typeof(UNMATCHED)}}(
+    queue = Vector{MatchedNodeType{eltype(graph)}}(
         [n for n in set1 if matching[n] == UNMATCHED]
     )
 
@@ -67,9 +68,9 @@ Compute augmenting paths and update the matching
 """
 function _hk_augmenting_dfs!(
     graph::Graph{T},
-    root::Union{T, typeof(UNMATCHED)},
-    matching::Dict{T, Union{T, typeof(UNMATCHED)}},
-    distance::Dict{Union{T, typeof(UNMATCHED)}, Float64},
+    root::MatchedNodeType{T},
+    matching::Dict{T, MatchedNodeType{T}},
+    distance::Dict{MatchedNodeType{T}, Float64},
 )::Bool where {T <: Integer}
     if root != UNMATCHED
         for n in neighbors(graph, root)
@@ -129,10 +130,10 @@ function hopcroft_karp_matching(
     set1 = [n for n in vertices(graph) if bmap[n] == 1]
 
     # Initialize "state" that is modified during the algorithm
-    matching = Dict{eltype(graph), Union{eltype(graph), typeof(UNMATCHED)}}(
+    matching = Dict{eltype(graph), MatchedNodeType{eltype(graph)}}(
         n => UNMATCHED for n in vertices(graph)
     )
-    distance = Dict{Union{eltype(graph), typeof(UNMATCHED)}, Float64}()
+    distance = Dict{MatchedNodeType{eltype(graph)}, Float64}()
 
     # BFS to determine whether any augmenting paths exist
     while _hk_augmenting_bfs!(graph, set1, matching, distance)

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -1,5 +1,4 @@
-const UNMATCHED = nothing
-MatchedNodeType{T} = Union{T, typeof(UNMATCHED)}
+include("hopcroft_karp.jl")
 
 """
     AbstractMaximumMatchingAlgorithm
@@ -15,146 +14,6 @@ The [Hopcroft-Karp algorithm](https://en.wikipedia.org/wiki/Hopcroft-Karp_algori
 for computing a maximum cardinality matching of a bipartite graph.
 """
 struct HopcroftKarpAlgorithm <: AbstractMaximumMatchingAlgorithm end
-
-"""
-Determine whether an augmenting path exists and mark distances
-so we can compute shortest-length augmenting paths in the DFS.
-"""
-function _hk_augmenting_bfs!(
-    graph::AbstractGraph{T},
-    set1::Vector{T},
-    matching::Dict{T, MatchedNodeType{T}},
-    distance::Dict{MatchedNodeType{T}, Float64},
-)::Bool where {T <: Integer}
-    # Initialize queue with the unmatched nodes in set1
-    queue = Vector{MatchedNodeType{eltype(graph)}}(
-        [n for n in set1 if matching[n] == UNMATCHED]
-    )
-
-    distance[UNMATCHED] = Inf
-    for n in set1
-        if matching[n] == UNMATCHED
-            distance[n] = 0.0
-        else
-            distance[n] = Inf
-        end
-    end
-
-    while !isempty(queue)
-        n1 = popfirst!(queue)
-
-        # If n1 is (a) matched or (b) in set1
-        if distance[n1] < Inf && n1 != UNMATCHED
-            for n2 in neighbors(graph, n1)
-                # If n2 has not been encountered
-                if distance[matching[n2]] == Inf
-                    # Give it a distance
-                    distance[matching[n2]] = distance[n1] + 1
-
-                    # Note that n2 could be unmatched
-                    push!(queue, matching[n2])
-                end
-            end
-        end
-    end
-
-    found_augmenting_path = (distance[UNMATCHED] < Inf)
-    # The distance to UNMATCHED is the length of the shortest augmenting path
-    return found_augmenting_path
-end
-
-"""
-Compute augmenting paths and update the matching
-"""
-function _hk_augmenting_dfs!(
-    graph::AbstractGraph{T},
-    root::MatchedNodeType{T},
-    matching::Dict{T, MatchedNodeType{T}},
-    distance::Dict{MatchedNodeType{T}, Float64},
-)::Bool where {T <: Integer}
-    if root != UNMATCHED
-        for n in neighbors(graph, root)
-            # Traverse edges of the minimum-length alternating path
-            if distance[matching[n]] == distance[root] + 1
-                if _hk_augmenting_dfs!(graph, matching[n], matching, distance)
-                    # If the edge is part of an augmenting path, update the
-                    # matching
-                    matching[root] = n
-                    matching[n] = root
-                    return true
-                end
-            end
-        end
-        # If we could not find a matched edge that was part of an augmenting
-        # path, we need to make sure we don't consider this vertex again
-        distance[root] = Inf
-        return false
-    else
-        # Return true to indicate that we are part of an augmenting path
-        return true
-    end
-end
-
-"""
-    hopcroft_karp_matching(graph::AbstractGraph)::Dict
-
-Compute a maximum-cardinality matching of a bipartite graph via the
-[Hopcroft-Karp algorithm](https://en.wikipedia.org/wiki/Hopcroft-Karp_algorithm).
-
-The return type is a dict mapping nodes to nodes. All matched nodes are included
-as keys. For example, if `i` is matched with `j`, `i => j` and `j => i` are both
-included in the returned dict.
-
-### Performance
-
-The algorithms runs in O((m + n)n^0.5), where n is the number of vertices and
-m is the number of edges. As it does not assume the number of edges is O(n^2),
-this algorithm is particularly effective for sparse bipartite graphs.
-
-### Arguments
-
-* `graph`: The bipartite `Graph` for which a maximum matching is computed
-
-### Exceptions
-
-* `ArgumentError`: The provided graph is not bipartite
-
-"""
-function hopcroft_karp_matching(
-   graph::AbstractGraph{T}
-)::Dict{T, T} where {T <: Integer}
-    bmap = bipartite_map(graph)
-    if length(bmap) != nv(graph)
-        throw(ArgumentError("Provided graph is not bipartite"))
-    end
-    set1 = [n for n in vertices(graph) if bmap[n] == 1]
-
-    # Initialize "state" that is modified during the algorithm
-    matching = Dict{eltype(graph), MatchedNodeType{eltype(graph)}}(
-        n => UNMATCHED for n in vertices(graph)
-    )
-    distance = Dict{MatchedNodeType{eltype(graph)}, Float64}()
-
-    # BFS to determine whether any augmenting paths exist
-    while _hk_augmenting_bfs!(graph, set1, matching, distance)
-        for n1 in set1
-            if matching[n1] == UNMATCHED
-                # DFS to update the matching along a minimum-length
-                # augmenting path
-                _hk_augmenting_dfs!(graph, n1, matching, distance)
-            end
-        end
-    end
-    matching = Dict(i => j for (i, j) in matching if j != UNMATCHED)
-    return matching
-end
-
-function maximum_cardinality_matching(
-    graph::AbstractGraph{T},
-    algorithm::HopcroftKarpAlgorithm,
-)::Dict{T, T} where {T <: Integer}
-    return hopcroft_karp_matching(graph)
-end
 
 """
     maximum_cardinality_matching(
@@ -208,4 +67,11 @@ function maximum_cardinality_matching(
     algorithm::AbstractMaximumMatchingAlgorithm = HopcroftKarpAlgorithm(),
 )::Dict{T, T} where {T <: Integer}
     return maximum_cardinality_matching(graph, algorithm)
+end
+
+function maximum_cardinality_matching(
+    graph::AbstractGraph{T},
+    algorithm::HopcroftKarpAlgorithm,
+)::Dict{T, T} where {T <: Integer}
+    return hopcroft_karp_matching(graph)
 end

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -3,6 +3,21 @@ using Graphs
 const UNMATCHED = -1
 
 """
+    AbstractMaximumMatchingAlgorithm
+
+Abstract type for maximum cardinality matching algorithms
+"""
+abstract type AbstractMaximumMatchingAlgorithm end
+
+"""
+    HopcroftKarpAlgorithm
+
+The [Hopcroft-Karp algorithm](https://en.wikipedia.org/wiki/Hopcroft-Karp_algorithm)
+for computing a maximum cardinality matching of a bipartite graph.
+"""
+struct HopcroftKarpAlgorithm <: AbstractMaximumMatchingAlgorithm end
+
+"""
 Determine whether an augmenting path exists and mark distances
 so we can compute shortest-length augmenting paths in the DFS.
 """
@@ -99,6 +114,10 @@ this algorithm is particularly effective for sparse bipartite graphs.
 
 * `graph`: The bipartite `Graph` for which a maximum matching is computed
 
+### Exceptions
+
+* `ArgumentError`: The provided graph is not bipartite
+
 ### Example
 ```jldoctest
 julia> using Graphs
@@ -118,7 +137,7 @@ Dict{Int64, Int64} with 6 entries:
   1 => 4
 ```
 """
-function hopcroft_karp_matching(graph::Graph)
+function hopcroft_karp_matching(graph::Graph)::Dict{Int, Int}
     bmap = bipartite_map(graph)
     if length(bmap) != nv(graph)
         throw(ArgumentError("Provided graph is not bipartite"))
@@ -141,4 +160,48 @@ function hopcroft_karp_matching(graph::Graph)
     end
     matching = Dict(i => j for (i, j) in matching if j != UNMATCHED)
     return matching
+end
+
+function maximum_cardinality_matching(
+    graph::Graph,
+    algorithm::HopcroftKarpAlgorithm,
+)::Dict{Int, Int}
+    return hopcroft_karp_matching(graph)
+end
+
+"""
+    maximum_cardinality_matching(
+        graph::Graph,
+        algorithm::AbstractMaximumMatchingAlgorithm,
+    )::Dict{Int, Int}
+
+Compute a maximum-cardinality matching.
+
+The return type is a dict mapping nodes to nodes. All matched nodes are included
+as keys. For example, if `i` is matched with `j`, `i => j` and `j => i` are both
+included in the returned dict.
+
+### Arguments
+
+* `graph`: The bipartite `Graph` for which a maximum matching is computed
+
+* `algorithm`: The algorithm to use to compute the matching. Default is
+  `HopcroftKarpAlgorithm`.
+
+### Algorithms
+Currently implemented algorithms are:
+
+* Hopcroft-Karp
+
+### Exceptions
+
+* `ArgumentError`: The provided graph is not bipartite but an algorithm that
+  only applies to bipartite graphs, e.g. Hopcroft-Karp, was chosen
+
+"""
+function maximum_cardinality_matching(
+    graph::Graph;
+    algorithm::AbstractMaximumMatchingAlgorithm = HopcroftKarpAlgorithm(),
+)::Dict{Int, Int}
+    return maximum_cardinality_matching(graph, algorithm)
 end

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -72,6 +72,22 @@ function _hk_dfs!(
     return true
 end
 
+"""
+    hopcroft_karp_matching(graph::Graph, set1::Set)::Dict
+
+Compute a maximum-cardinality matching of a bipartite graph via the
+[Hopcroft-Karp algorithm](https://en.wikipedia.org/wiki/Hopcroft-Karp_algorithm).
+
+The return type is a dict mapping nodes in `set1` to other nodes *and* other
+nodes back to their matched nodes in `set`.
+
+### Arguments
+
+* `graph`: The bipartite `Graph` for which a maximum matching is computed
+
+* `set1`: A set of vertices in a bipartition
+
+"""
 function hopcroft_karp_matching(graph::Graph, set1::Set)
     matching = Dict(n => UNMATCHED for n in vertices(graph))
     set1 = [n for n in vertices(graph) if n in set1]

--- a/src/matching/maximum_matching.jl
+++ b/src/matching/maximum_matching.jl
@@ -1,0 +1,88 @@
+using Graphs
+
+const UNMATCHED = -1
+
+"""
+Compute the length of the shortest augmenting path
+"""
+function _hk_augmenting_bfs!(
+    graph::Graph,
+    set1::Vector{Int},
+    matching::Dict{Int, Int},
+    distance::Dict{Int, Float64},
+)::Bool
+    # Initialize queue with the unmatched nodes in set1
+    queue = Vector{Int}([n for n in set1 if matching[n] == UNMATCHED])
+
+    distance[UNMATCHED] = Inf
+    for n in set1
+        if matching[n] == UNMATCHED
+            distance[n] = 0.0
+        else
+            distance[n] = Inf
+        end
+    end
+
+    while !isempty(queue)
+        n1 = popfirst!(queue)
+
+        # If n1 is (a) matched or (b) in set1
+        if distance[n1] < Inf && n1 != UNMATCHED
+            for n2 in neighbors(graph, n1)
+                # If n2 has not been encountered
+                if distance[matching[n2]] == Inf
+                    # Give it a distance
+                    distance[matching[n2]] = distance[n1] + 1
+
+                    # Note that n2 could be unmatched
+                    push!(queue, matching[n2])
+                end
+            end
+        end
+    end
+
+    found_augmenting_path = (distance[UNMATCHED] < Inf)
+    # The distance to UNMATCHED is the length of the shortest augmenting path
+    return found_augmenting_path
+end
+
+"""
+Compute augmenting paths
+"""
+function _hk_dfs!(
+    graph::Graph,
+    root::Int,
+    matching::Dict{Int, Int},
+    distance::Dict{Int, Float64},
+)::Bool
+    if root != UNMATCHED
+        for n in neighbors(graph, root)
+            # We traverse along matched edges
+            if distance[matching[n]] == distance[root] + 1
+                if _hk_dfs!(graph, matching[n], matching, distance)
+                    matching[root] = n
+                    matching[n] = root
+                    return true
+                end
+            end
+        end
+        distance[root] = Inf
+        return false
+    end
+    return true
+end
+
+function hopcroft_karp_matching(graph::Graph, set1::Set)
+    matching = Dict(n => UNMATCHED for n in vertices(graph))
+    set1 = [n for n in vertices(graph) if n in set1]
+    distance = Dict{Int, Float64}()
+    while _hk_augmenting_bfs!(graph, set1, matching, distance)
+        for n1 in set1
+            if matching[n1] == UNMATCHED
+                _hk_dfs!(graph, n1, matching, distance)
+            end
+        end
+    end
+    matching = Dict(i => j for (i, j) in matching if j != UNMATCHED)
+    return matching
+end

--- a/test/matching/maximum_matching.jl
+++ b/test/matching/maximum_matching.jl
@@ -52,8 +52,6 @@ function test_imperfect_matching()
     add_edge!(g, (8, 16))
 
     matching = hopcroft_karp_matching(g)
-    println(matching)
-    println(length(matching))
     @test length(matching) == 14
 
     possibly_unmatched_1 = Set([5, 6, 7, 8])

--- a/test/matching/maximum_matching.jl
+++ b/test/matching/maximum_matching.jl
@@ -17,6 +17,55 @@ function test_simple_example()
     add_edge!(g, (5, 6))
     add_edge!(g, (5, 9))
 
+    matching = maximum_cardinality_matching(g)
+    @test length(matching) == 10
+    for i in 1:10
+        @test i in keys(matching)
+        @test matching[i] in neighbors(g, i)
+    end
+end
+
+function test_simple_example_algorithm_argument()
+    # From the wikipedia page for the Hopcroft-Karp algorithm
+    # https://en.wikipedia.org/wiki/Hopcroft–Karp_algorithm
+    g = Graph()
+    add_vertices!(g, 10)
+    add_edge!(g, (1, 6))
+    add_edge!(g, (1, 7))
+    add_edge!(g, (2, 6))
+    add_edge!(g, (2, 10))
+    add_edge!(g, (3, 8))
+    add_edge!(g, (3, 9))
+    add_edge!(g, (4, 6))
+    add_edge!(g, (4, 10))
+    add_edge!(g, (5, 6))
+    add_edge!(g, (5, 9))
+
+    algorithm = HopcroftKarpAlgorithm()
+    matching = maximum_cardinality_matching(g, algorithm)
+    @test length(matching) == 10
+    for i in 1:10
+        @test i in keys(matching)
+        @test matching[i] in neighbors(g, i)
+    end
+end
+
+function test_simple_example_hopcroft_karp()
+    # From the wikipedia page for the Hopcroft-Karp algorithm
+    # https://en.wikipedia.org/wiki/Hopcroft–Karp_algorithm
+    g = Graph()
+    add_vertices!(g, 10)
+    add_edge!(g, (1, 6))
+    add_edge!(g, (1, 7))
+    add_edge!(g, (2, 6))
+    add_edge!(g, (2, 10))
+    add_edge!(g, (3, 8))
+    add_edge!(g, (3, 9))
+    add_edge!(g, (4, 6))
+    add_edge!(g, (4, 10))
+    add_edge!(g, (5, 6))
+    add_edge!(g, (5, 9))
+
     matching = hopcroft_karp_matching(g)
     @test length(matching) == 10
     for i in 1:10
@@ -51,7 +100,7 @@ function test_imperfect_matching()
     add_edge!(g, (7, 16))
     add_edge!(g, (8, 16))
 
-    matching = hopcroft_karp_matching(g)
+    matching = maximum_cardinality_matching(g)
     @test length(matching) == 14
 
     possibly_unmatched_1 = Set([5, 6, 7, 8])
@@ -74,7 +123,7 @@ end
 
 function test_complete_bipartite()
     g = complete_bipartite_graph(10, 20)
-    matching = hopcroft_karp_matching(g)
+    matching = maximum_cardinality_matching(g)
     @test length(matching) == 20
     for i in 1:10
         @test i in keys(matching)
@@ -84,11 +133,16 @@ end
 
 function test_not_bipartite()
     g = complete_graph(5)
-    @test_throws(ArgumentError, hopcroft_karp_matching(g))
+    @test_throws(ArgumentError, maximum_cardinality_matching(g))
 end
 
-@testset "Hopcroft-Karp matching" begin
+@testset "Maximum cardinality matching" begin
     test_simple_example()
+    test_simple_example_algorithm_argument()
+    test_simple_example_hopcroft_karp()
+
+    # NOTE: Right now there is only one algorithm to test. When we add more,
+    # we should loop over the algorithms to run these tests for each.
     test_imperfect_matching()
     test_complete_bipartite()
     test_not_bipartite()

--- a/test/matching/maximum_matching.jl
+++ b/test/matching/maximum_matching.jl
@@ -74,6 +74,31 @@ function test_simple_example_hopcroft_karp()
     end
 end
 
+function test_simple_example_different_node_type()
+    # From the wikipedia page for the Hopcroft-Karp algorithm
+    # https://en.wikipedia.org/wiki/Hopcroft–Karp_algorithm
+    g = Graph{UInt8}()
+    add_vertices!(g, 10)
+    add_edge!(g, (1, 6))
+    add_edge!(g, (1, 7))
+    add_edge!(g, (2, 6))
+    add_edge!(g, (2, 10))
+    add_edge!(g, (3, 8))
+    add_edge!(g, (3, 9))
+    add_edge!(g, (4, 6))
+    add_edge!(g, (4, 10))
+    add_edge!(g, (5, 6))
+    add_edge!(g, (5, 9))
+
+    matching = hopcroft_karp_matching(g)
+    @test eltype(matching) === Pair{UInt8, UInt8}
+    @test length(matching) == 10
+    for i in 1:10
+        @test i in keys(matching)
+        @test matching[i] in neighbors(g, i)
+    end
+end
+
 function test_imperfect_matching()
     g = Graph()
     add_vertices!(g, 16)
@@ -102,7 +127,6 @@ function test_imperfect_matching()
 
     matching = maximum_cardinality_matching(g)
     @test length(matching) == 14
-
     possibly_unmatched_1 = Set([5, 6, 7, 8])
     possibly_unmatched_2 = Set([9, 10, 11, 12, 13])
 
@@ -140,6 +164,7 @@ end
     test_simple_example()
     test_simple_example_algorithm_argument()
     test_simple_example_hopcroft_karp()
+    test_simple_example_different_node_type()
 
     # NOTE: Right now there is only one algorithm to test. When we add more,
     # we should loop over the algorithms to run these tests for each.

--- a/test/matching/maximum_matching.jl
+++ b/test/matching/maximum_matching.jl
@@ -1,0 +1,97 @@
+using Graphs
+using Test
+
+function test_simple_example()
+    # From the wikipedia page for the Hopcroft-Karp algorithm
+    # https://en.wikipedia.org/wiki/Hopcroft–Karp_algorithm
+    g = Graph()
+    add_vertices!(g, 10)
+    add_edge!(g, (1, 6))
+    add_edge!(g, (1, 7))
+    add_edge!(g, (2, 6))
+    add_edge!(g, (2, 10))
+    add_edge!(g, (3, 8))
+    add_edge!(g, (3, 9))
+    add_edge!(g, (4, 6))
+    add_edge!(g, (4, 10))
+    add_edge!(g, (5, 6))
+    add_edge!(g, (5, 9))
+
+    matching = hopcroft_karp_matching(g)
+    @test length(matching) == 10
+    for i in 1:10
+        @test i in keys(matching)
+        @test matching[i] in neighbors(g, i)
+    end
+end
+
+function test_imperfect_matching()
+    g = Graph()
+    add_vertices!(g, 16)
+    add_edge!(g, (1, 9))
+    add_edge!(g, (2, 9))
+    add_edge!(g, (3, 9))
+    add_edge!(g, (1, 10))
+    add_edge!(g, (4, 10))
+    add_edge!(g, (2, 11))
+    add_edge!(g, (4, 11))
+    add_edge!(g, (3, 12))
+    add_edge!(g, (4, 12))
+    add_edge!(g, (1, 13))
+    add_edge!(g, (2, 13))
+    add_edge!(g, (3, 13))
+    add_edge!(g, (4, 13))
+    add_edge!(g, (1, 14))
+    add_edge!(g, (5, 14))
+    add_edge!(g, (8, 14))
+    add_edge!(g, (2, 15))
+    add_edge!(g, (6, 15))
+    add_edge!(g, (8, 15))
+    add_edge!(g, (3, 16))
+    add_edge!(g, (7, 16))
+    add_edge!(g, (8, 16))
+
+    matching = hopcroft_karp_matching(g)
+    println(matching)
+    println(length(matching))
+    @test length(matching) == 14
+
+    possibly_unmatched_1 = Set([5, 6, 7, 8])
+    possibly_unmatched_2 = Set([9, 10, 11, 12, 13])
+
+    for i in 1:16
+        if i in keys(matching)
+            # Sanity check
+            @test matching[i] in neighbors(g, i)
+        elseif i <= 8
+            # Make sure the unmatched vertices match what we predict.
+            # (Possibly unmatched vertices are computed via the
+            # Dulmage-Mendelsohn decomposition.)
+            @test i in possibly_unmatched_1
+        else
+            @test i in possibly_unmatched_2
+        end
+    end
+end
+
+function test_complete_bipartite()
+    g = complete_bipartite_graph(10, 20)
+    matching = hopcroft_karp_matching(g)
+    @test length(matching) == 20
+    for i in 1:10
+        @test i in keys(matching)
+        @test matching[i] > 10
+    end
+end
+
+function test_not_bipartite()
+    g = complete_graph(5)
+    @test_throws(ArgumentError, hopcroft_karp_matching(g))
+end
+
+@testset "Hopcroft-Karp matching" begin
+    test_simple_example()
+    test_imperfect_matching()
+    test_complete_bipartite()
+    test_not_bipartite()
+end

--- a/test/matching/maximum_matching.jl
+++ b/test/matching/maximum_matching.jl
@@ -91,7 +91,7 @@ function test_simple_example_different_node_type()
     add_edge!(g, (5, 9))
 
     matching = hopcroft_karp_matching(g)
-    @test eltype(matching) === Pair{UInt8, UInt8}
+    @test eltype(matching) === Pair{UInt8,UInt8}
     @test length(matching) == 10
     for i in 1:10
         @test i in keys(matching)

--- a/test/matching/maximum_matching.jl
+++ b/test/matching/maximum_matching.jl
@@ -160,6 +160,24 @@ function test_not_bipartite()
     @test_throws(ArgumentError, maximum_cardinality_matching(g))
 end
 
+function test_empty()
+    g = Graph()
+    matching = maximum_cardinality_matching(g)
+    @test length(matching) == 0
+end
+
+function test_disconnected()
+    g = Graph()
+    add_vertices!(g, 5)
+    add_edge!(g, (1, 3))
+    add_edge!(g, (2, 4))
+    add_edge!(g, (2, 5))
+    matching = maximum_cardinality_matching(g)
+    @test length(matching) == 4
+    @test matching[1] == 3 && matching[3] == 1
+    @test matching[2] == 4 || matching[2] == 5
+end
+
 @testset "Maximum cardinality matching" begin
     test_simple_example()
     test_simple_example_algorithm_argument()
@@ -171,4 +189,6 @@ end
     test_imperfect_matching()
     test_complete_bipartite()
     test_not_bipartite()
+    test_empty()
+    test_disconnected()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,6 +151,7 @@ tests = [
     "vertexcover/random_vertex_cover",
     "trees/prufer",
     "experimental/experimental",
+    "matching/maximum_matching",
 ]
 
 @testset verbose = true "Graphs" begin


### PR DESCRIPTION
The Hopcroft-Karp algorithm computes a maximum-cardinality matching of a bipartite graph. This algorithm is very useful, and I would like to use it in some other projects.

I'm opening this PR here rather than in GraphsMatching as this PR does not add dependencies, and there has been some talk, e.g. in #191, of adding basic matching functionality to the Graphs.jl repository.

## Additions
- `maximum_cardinality_matching` function. This accepts a graph, and an optional `AbstractMaximumMatchingAlgorithm` to specify which algorithm to use (only Hopcroft-Karp is available for now). This design is motivated by the discussion in #264.
- `hopcroft_karp_matching` function, which implements the Hopcroft-Karp algorithm for maximum cardinality matching on a bipartite graph
- Tests and basic documentation