### PR TITLE
Avoid the `zeros(nthreads())[threadid()]` buffering pattern

### DIFF
--- a/src/Parallel/centrality/stress.jl
+++ b/src/Parallel/centrality/stress.jl
@@ -47,9 +47,10 @@ function threaded_stress_centrality(g::AbstractGraph, vs=vertices(g))::Vector{In
     d, r = divrem(k, Threads.nthreads())
     ntasks = d == 0 ? r : Threads.nthreads()
     local_stress = [zeros(Int, n_v) for _ in 1:ntasks]
+    task_size = cld(k, ntasks)
 
-    @sync for t in 1:ntasks
-        Threads.@spawn for s in @view(vs[(d*(t-1)+1):(d*t + (t <= r))])
+    @sync for (t, task_range) in enumerate(Iterators.partition(1:k, task_size))
+        Threads.@spawn for s in @view(vs[task_range])
             if degree(g, s) > 0  # this might be 1?
                 state = Graphs.dijkstra_shortest_paths(g, s; allpaths=true, trackvertices=true)
                 Graphs._stress_accumulate_basic!(local_stress[t], state, g, s)

--- a/src/Parallel/centrality/stress.jl
+++ b/src/Parallel/centrality/stress.jl
@@ -44,14 +44,16 @@ function threaded_stress_centrality(g::AbstractGraph, vs=vertices(g))::Vector{In
     isdir = is_directed(g)
 
     # Parallel reduction
-    local_stress = [zeros(Int, n_v) for _ in 1:nthreads()]
+    d, r = divrem(k, Threads.nthreads())
+    ntasks = d == 0 ? r : Threads.nthreads()
+    local_stress = [zeros(Int, n_v) for _ in 1:ntasks]
 
-    Base.Threads.@threads for s in vs
-        if degree(g, s) > 0  # this might be 1?
-            state = Graphs.dijkstra_shortest_paths(g, s; allpaths=true, trackvertices=true)
-            Graphs._stress_accumulate_basic!(
-                local_stress[Base.Threads.threadid()], state, g, s
-            )
+    @sync for t in 1:ntasks
+        Threads.@spawn for s in @view(vs[(d*(t-1)+1):(d*t + (t <= r))])
+            if degree(g, s) > 0  # this might be 1?
+                state = Graphs.dijkstra_shortest_paths(g, s; allpaths=true, trackvertices=true)
+                Graphs._stress_accumulate_basic!(local_stress[t], state, g, s)
+            end
         end
     end
     return reduce(+, local_stress)

--- a/src/Parallel/utils.jl
+++ b/src/Parallel/utils.jl
@@ -44,9 +44,10 @@ function threaded_generate_reduce(
     ntasks = d == 0 ? r : Threads.nthreads()
     min_set = [Vector{T}() for _ in 1:ntasks]
     is_undef = ones(Bool, ntasks)
+    task_size = cld(reps, ntasks)
 
-    @sync for t in 1:ntasks
-        Threads.@spawn for _ in 1:(d + (t <= r))
+    @sync for (t, task_range) in enumerate(Iterators.partition(1:reps, task_size))
+        Threads.@spawn for _ in task_range
             next_set = gen_func(g)
             if is_undef[t] || comp(next_set, min_set[t])
                 min_set[t] = next_set

--- a/src/Parallel/utils.jl
+++ b/src/Parallel/utils.jl
@@ -40,20 +40,23 @@ Multi-threaded implementation of [`generate_reduce`](@ref).
 function threaded_generate_reduce(
     g::AbstractGraph{T}, gen_func::Function, comp::Comp, reps::Integer
 ) where {T<:Integer,Comp}
-    n_t = Base.Threads.nthreads()
-    is_undef = ones(Bool, n_t)
-    min_set = [Vector{T}() for _ in 1:n_t]
-    Base.Threads.@threads for _ in 1:reps
-        t = Base.Threads.threadid()
-        next_set = gen_func(g)
-        if is_undef[t] || comp(next_set, min_set[t])
-            min_set[t] = next_set
-            is_undef[t] = false
+    d, r = divrem(reps, Threads.nthreads())
+    ntasks = d == 0 ? r : Threads.nthreads()
+    min_set = [Vector{T}() for _ in 1:ntasks]
+    is_undef = ones(Bool, ntasks)
+
+    @sync for t in 1:ntasks
+        Threads.@spawn for _ in 1:(d + (t <= r))
+            next_set = gen_func(g)
+            if is_undef[t] || comp(next_set, min_set[t])
+                min_set[t] = next_set
+                is_undef[t] = false
+            end
         end
     end
 
     min_ind = 0
-    for i in filter((j) -> !is_undef[j], 1:n_t)
+    for i in filter((j) -> !is_undef[j], 1:ntasks)
         if min_ind == 0 || comp(min_set[i], min_set[min_ind])
             min_ind = i
         end


### PR DESCRIPTION
As recommended in this blogpost https://julialang.org/blog/2023/07/PSA-dont-use-threadid/