### PR TITLE
Remove non-default GenericGraph constructor

### DIFF
--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -36,10 +36,6 @@ struct GenericGraph{T} <: Graphs.AbstractGraph{T}
     g::SimpleGraph{T}
 end
 
-function GenericGraph(elist::Vector{Graphs.SimpleGraphEdge{T}}) where {T<:Integer}
-    return GenericGraph{T}(SimpleGraph(elist))
-end
-
 """
     GenericDiGraph{T} <: Graphs.AbstractGraph{T}
 

--- a/test/traversals/eulerian.jl
+++ b/test/traversals/eulerian.jl
@@ -1,29 +1,28 @@
 @testset "Eulerian tours/cycles" begin
     # a cycle (identical start/end)
-    g0 = GenericGraph([Edge(1,2), Edge(2,3), Edge(3,1)])
+    g0 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,1)]))
     @test eulerian(g0, 1) == eulerian(g0)
     @test last(eulerian(g0, 1)) == 1 # a cycle
 
     # a tour (different start/end)
-    g1 = GenericGraph([Edge(1,2), Edge(2,3), Edge(3,4)])
+    g1 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,4)]))
     @test eulerian(g1, 1) == [1,2,3,4]
     @test_throws ErrorException("starting vertex has even degree but there are other vertices with odd degree: a eulerian cycle does not exist") eulerian(g1, 2)
     
     # a cycle with a node (vertex 2) with multiple neighbors
-    g2 = GenericGraph([Edge(1,2), Edge(2,3), Edge(3,4), Edge(4,1), Edge(2,5), Edge(5,6), 
-                      Edge(6,2)])
+    g2 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,4), Edge(4,1), Edge(2,5), Edge(5,6), Edge(6,2)]))
     @test eulerian(g2) == eulerian(g2, 1) == [1, 2, 5, 6, 2, 3, 4, 1]
 
     # graph with odd-degree vertices
-    g3 = GenericGraph([Edge(1,2), Edge(2,3), Edge(3,4), Edge(2,4), Edge(4,1), Edge(4,2)])
+    g3 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,4), Edge(2,4), Edge(4,1), Edge(4,2)]))
     @test_throws ErrorException("starting vertex has even degree but there are other vertices with odd degree: a eulerian cycle does not exist") eulerian(g3, 1)
 
     # start/end point not in graph
     @test_throws ErrorException("starting vertex is not in the graph") eulerian(g3, 5)
 
     # disconnected components
-    g4 = GenericGraph([Edge(1,2), Edge(2,3), Edge(3,1),  # component 1
-                      Edge(4,5), Edge(5,6), Edge(6,4)]) # component 2
+    g4 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,1),  # component 1
+                      Edge(4,5), Edge(5,6), Edge(6,4)])) # component 2
     @test_throws ErrorException("graph is not connected: a eulerian cycle/trail does not exist") eulerian(g4)
 
     # zero-degree nodes


### PR DESCRIPTION
This PR removes the `GenericGraph(elist)` constructor.

The reason why we do not want to have such a constructor, is that we use `GenericGraph` to verify that an interface that uses an `AbstractGraph` only uses the methods as defined in the informal interface.

In the future, we might add convenience functions such as `generic_graph(elist)`  that could help us de-clutter our tests.