### PR TITLE
Fix formatting for file vf2.jl and remove `ignore` in test + autoformatter pass

### DIFF
--- a/benchmark/core.jl
+++ b/benchmark/core.jl
@@ -34,4 +34,6 @@ end
 
 suite["core"]["has_edge"] = BenchmarkGroup(["graphs", "digraphs"])
 suite["core"]["has_edge"]["graphs"] = @benchmarkable [all_has_edge(g) for (n, g) in $GRAPHS]
-suite["core"]["has_edge"]["digraphs"] = @benchmarkable [all_has_edge(g) for (n, g) in $DIGRAPHS]
+suite["core"]["has_edge"]["digraphs"] = @benchmarkable [
+    all_has_edge(g) for (n, g) in $DIGRAPHS
+]

--- a/src/Experimental/vf2.jl
+++ b/src/Experimental/vf2.jl
@@ -658,7 +658,7 @@ function all_isomorph(
     edge_relation::Union{Nothing,Function}=nothing,
 )::Channel{Vector{Tuple{eltype(g1),eltype(g2)}}}
     T = Vector{Tuple{eltype(g1),eltype(g2)}}
-    !could_have_isomorph(g1, g2) && return Channel(_ -> nothing, ctype = T)  # TODO: fix problem with JuliaFormatter, right now the whole file is ignored
+    !could_have_isomorph(g1, g2) && return Channel(_ -> nothing, ctype = T)
     make_callback(c) = vmap -> (put!(c, collect(zip(vmap, 1:length(vmap)))), return true)
     ch::Channel{T} = Channel(; ctype=T) do c
         vf2(

--- a/src/Parallel/centrality/stress.jl
+++ b/src/Parallel/centrality/stress.jl
@@ -52,7 +52,9 @@ function threaded_stress_centrality(g::AbstractGraph, vs=vertices(g))::Vector{In
     @sync for (t, task_range) in enumerate(Iterators.partition(1:k, task_size))
         Threads.@spawn for s in @view(vs[task_range])
             if degree(g, s) > 0  # this might be 1?
-                state = Graphs.dijkstra_shortest_paths(g, s; allpaths=true, trackvertices=true)
+                state = Graphs.dijkstra_shortest_paths(
+                    g, s; allpaths=true, trackvertices=true
+                )
                 Graphs._stress_accumulate_basic!(local_stress[t], state, g, s)
             end
         end

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -443,7 +443,9 @@ function newman_watts_strogatz(
     rng::Union{Nothing,AbstractRNG}=nothing,
     seed::Union{Nothing,Integer}=nothing,
 )
-    return watts_strogatz(n, k, β; is_directed=is_directed, remove_edges=false, rng=rng, seed=seed)
+    return watts_strogatz(
+        n, k, β; is_directed=is_directed, remove_edges=false, rng=rng, seed=seed
+    )
 end
 
 function _suitable(edges::Set{SimpleEdge{T}}, potential_edges::Dict{T,T}) where {T<:Integer}

--- a/src/SimpleGraphs/simpleedge.jl
+++ b/src/SimpleGraphs/simpleedge.jl
@@ -34,4 +34,6 @@ function ==(e1::AbstractSimpleEdge, e2::AbstractSimpleEdge)
     return (src(e1) == src(e2) && dst(e1) == dst(e2))
 end
 hash(e::AbstractSimpleEdge, h::UInt) = hash(src(e), hash(dst(e), h))
-isless(e1::AbstractSimpleEdge, e2::AbstractSimpleEdge) = (src(e1) < src(e2)) || ((src(e1) == src(e2)) && (dst(e1) < dst(e2)))
+function isless(e1::AbstractSimpleEdge, e2::AbstractSimpleEdge)
+    return (src(e1) < src(e2)) || ((src(e1) == src(e2)) && (dst(e1) < dst(e2)))
+end

--- a/src/centrality/stress.jl
+++ b/src/centrality/stress.jl
@@ -51,7 +51,9 @@ function stress_centrality(
     rng::Union{Nothing,AbstractRNG}=nothing,
     seed::Union{Nothing,Integer}=nothing,
 )
-    return stress_centrality(g, sample(collect_if_not_vector(vertices(g)), k; rng=rng, seed=seed))
+    return stress_centrality(
+        g, sample(collect_if_not_vector(vertices(g)), k; rng=rng, seed=seed)
+    )
 end
 
 function _stress_accumulate_basic!(

--- a/src/core.jl
+++ b/src/core.jl
@@ -136,7 +136,6 @@ end
 
 degree(g::AbstractGraph, vs=vertices(g)) = [degree(g, x) for x in vs]
 
-
 """
     Δout(g)
 

--- a/src/graphcut/normalized_cut.jl
+++ b/src/graphcut/normalized_cut.jl
@@ -118,7 +118,7 @@ end
 function _recursive_normalized_cut(W, thres, num_cuts)
     m, n = size(W)
     (m <= 1) && return ones(Int, m) # trivial
-    D = Diagonal(vec(sum(W, dims=2)))
+    D = Diagonal(vec(sum(W; dims=2)))
 
     # check that the diagonal is not degenerated as otherwise invDroot errors
     dnz = abs.(diag(D)) .>= 1E-16
@@ -137,7 +137,7 @@ function _recursive_normalized_cut(W, thres, num_cuts)
     # At least some versions of ARPACK have a bug, this is a workaround
     invDroot = sqrt.(inv(D)) # equal to Cholesky factorization for diagonal D
     if n > 12
-        _, Q = eigs(invDroot' * (D - W) * invDroot, nev=12, which=SR())
+        _, Q = eigs(invDroot' * (D - W) * invDroot; nev=12, which=SR())
         (size(Q, 2) <= 1) && return collect(1:m) # no 2nd eigenvector
         ret = convert(Vector, real(view(Q, :, 2)))
     else
@@ -149,7 +149,7 @@ function _recursive_normalized_cut(W, thres, num_cuts)
     min_cost = Inf
     best_thres = -1
     vmin, vmax = extrema(v)
-    for t in range(vmin, stop=vmax, length=num_cuts)
+    for t in range(vmin; stop=vmax, length=num_cuts)
         cut = v .> t
         cost = _normalized_cut_cost(cut, W, D)
         if cost < min_cost

--- a/src/linalg/LinAlg.jl
+++ b/src/linalg/LinAlg.jl
@@ -52,7 +52,7 @@ function eigs(A; kwargs...)
     vals, vectors = partialeigen(schr[1])
     reved = (kwargs[:which] == LR() || kwargs[:which] == LM())
     k = min(get(kwargs, :nev, length(vals))::Int, length(vals))
-    perm = sortperm(vals, by=real, rev=reved)[1:k]
+    perm = sortperm(vals; by=real, rev=reved)[1:k]
     λ = vals[perm]
     Q = vectors[:, perm]
     return λ, Q

--- a/src/traversals/dfs.jl
+++ b/src/traversals/dfs.jl
@@ -53,7 +53,7 @@ end
                 end
             else
                 pop!(vertex_stack)
-                if vcolor[u] == 1 
+                if vcolor[u] == 1
                     vcolor[u] = 2
                 end
             end
@@ -107,10 +107,10 @@ function topological_sort_by_dfs end
                         push!(vertex_stack, n)
                     end
                 end
-                else
+            else
                 pop!(vertex_stack)
                 # if vcolor[u] == 2, the vertex was already explored and added to verts
-                if vcolor[u] == 1 
+                if vcolor[u] == 1
                     vcolor[u] = 2
                     pushfirst!(verts, u)
                 end

--- a/src/traversals/eulerian.jl
+++ b/src/traversals/eulerian.jl
@@ -17,7 +17,7 @@ cycle, the path starts _and_ ends at vertex `u`.
 """
 function eulerian(g::AbstractGraph{T}, u::T=first(vertices(g))) where {T}
     is_directed(g) && error("`eulerian` is not yet implemented for directed graphs")
-    
+
     _check_eulerian_input(g, u) # perform basic sanity checks
 
     g′ = SimpleGraph{T}(nv(g)) # copy `g` (mutated in `_eulerian!`)
@@ -28,7 +28,7 @@ function eulerian(g::AbstractGraph{T}, u::T=first(vertices(g))) where {T}
     return _eulerian!(g′, u)
 end
 
-@traitfn function _eulerian!(g::AG::(!IsDirected), u::T) where {T, AG<:AbstractGraph{T}}
+@traitfn function _eulerian!(g::AG::(!IsDirected), u::T) where {T,AG<:AbstractGraph{T}}
     # TODO: This uses Fleury's algorithm which is O(|E|²) in the number of edges |E|.
     #       Hierholzer's algorithm [https://en.wikipedia.org/wiki/Eulerian_path#Hierholzer's_algorithm]
     #       is presumably faster, running in O(|E|) time, but requires needing to keep track
@@ -67,7 +67,7 @@ end
             end
         end
     end
-    error("unreachable reached")
+    return error("unreachable reached")
 end
 
 @inline function _excludes_edge(u, w, e::AbstractEdge)
@@ -82,7 +82,7 @@ function _check_eulerian_input(g, u)
     end
 
     # special case: if any vertex has degree zero
-    if any(x->degree(g, x) == 0, vertices(g))
+    if any(x -> degree(g, x) == 0, vertices(g))
         error("some vertices have degree zero (are isolated) and cannot be reached")
     end
 
@@ -90,11 +90,15 @@ function _check_eulerian_input(g, u)
     du = degree(g, u)
     if iseven(du)     # cycle: start (u) == stop (v) - all nodes must have even degree
         if any(x -> isodd(degree(g, x)), vertices(g))
-            error("starting vertex has even degree but there are other vertices with odd degree: a eulerian cycle does not exist")
+            error(
+                "starting vertex has even degree but there are other vertices with odd degree: a eulerian cycle does not exist",
+            )
         end
     else # isodd(du)  # trail: start (u) != stop (v) - all nodes, except u and v, must have even degree
         if count(x -> iseven(degree(g, x)), vertices(g)) != 2
-            error("starting vertex has odd degree but the total number of vertices of odd degree is not equal to 2: a eulerian trail does not exist")
+            error(
+                "starting vertex has odd degree but the total number of vertices of odd degree is not equal to 2: a eulerian trail does not exist",
+            )
         end
     end
 

--- a/src/traversals/maxadjvisit.jl
+++ b/src/traversals/maxadjvisit.jl
@@ -16,8 +16,9 @@ weight of the cut that makes this partition. An optional `distmx` matrix
 of non-negative weights may be specified; if omitted, edge distances are
 assumed to be 1.
 """
-@traitfn function mincut(g::::(!IsDirected), distmx::AbstractMatrix{T}=weights(g)) where {T <: Real}
-
+@traitfn function mincut(
+    g::::(!IsDirected), distmx::AbstractMatrix{T}=weights(g)
+) where {T<:Real}
     nvg = nv(g)
     U = eltype(g)
 
@@ -31,12 +32,17 @@ assumed to be 1.
     # We need to mutate the weight matrix,
     # and we need it clean (0 for non edges)
     w = zeros(T, nvg, nvg)
-    size(distmx) != (nvg, nvg) && throw(ArgumentError("Adjacency / distance matrix size should match the number of vertices"))
+    size(distmx) != (nvg, nvg) && throw(
+        ArgumentError(
+            "Adjacency / distance matrix size should match the number of vertices"
+        ),
+    )
     @inbounds for e in edges(g)
         d = distmx[src(e), dst(e)]
         (d < 0) && throw(DomainError(w, "weigths should be non-negative"))
         w[src(e), dst(e)] = d
-        (d != distmx[dst(e), src(e)]) && throw(ArgumentError("Adjacency / distance matrix must be symmetric"))
+        (d != distmx[dst(e), src(e)]) &&
+            throw(ArgumentError("Adjacency / distance matrix must be symmetric"))
         w[dst(e), src(e)] = d
     end
     # we also need to mutate neighbors when merging vertices
@@ -58,7 +64,7 @@ assumed to be 1.
             pq[v] = zero(T)
         end
         for v in fadjlist[u]
-            (is_merged[v] || v == u ) && continue
+            (is_merged[v] || v == u) && continue
             pq[v] = w[u, v]
             cutweight += w[u, v]
         end

--- a/test/biconnectivity/articulation.jl
+++ b/test/biconnectivity/articulation.jl
@@ -33,7 +33,7 @@
 
     hint = blockdiag(wheel_graph(5), wheel_graph(5))
     add_edge!(hint, 5, 6)
-    for h in test_generic_graphs(hint, eltypes=[Int, UInt8, Int16])
+    for h in test_generic_graphs(hint; eltypes=[Int, UInt8, Int16])
         @test @inferred(articulation(h)) == [5, 6]
     end
 end

--- a/test/centrality/betweenness.jl
+++ b/test/centrality/betweenness.jl
@@ -1,8 +1,8 @@
 @testset "Betweenness" begin
     rng = StableRNG(1)
     # self loops
-    s1 = GenericGraph(SimpleGraph(Edge.([(1,2), (2,3), (3, 3)])))
-    s2 = GenericDiGraph(SimpleDiGraph(Edge.([(1,2), (2,3), (3, 3)])))
+    s1 = GenericGraph(SimpleGraph(Edge.([(1, 2), (2, 3), (3, 3)])))
+    s2 = GenericDiGraph(SimpleDiGraph(Edge.([(1, 2), (2, 3), (3, 3)])))
 
     g3 = GenericGraph(path_graph(5))
 

--- a/test/cycles/limited_length.jl
+++ b/test/cycles/limited_length.jl
@@ -50,8 +50,10 @@
         # This is probably because it uses induced_subgraph which fails on that graph type.
         octalengths, _ = simplecycleslength(octadg)
         for k in 1:6
-            @test sum(octalengths[1:k]) == length(simplecycles_limited_length(GenericGraph(octag), k))
-            @test sum(octalengths[1:k]) == length(simplecycles_limited_length(GenericDiGraph(octadg), k))
+            @test sum(octalengths[1:k]) ==
+                length(simplecycles_limited_length(GenericGraph(octag), k))
+            @test sum(octalengths[1:k]) ==
+                length(simplecycles_limited_length(GenericDiGraph(octadg), k))
         end
     end
 end

--- a/test/degeneracy.jl
+++ b/test/degeneracy.jl
@@ -22,7 +22,6 @@
             @test @inferred(k_crust(g, 2)) == k_crust(g, 2; corenum=corenum) == [9:21;]
             @test @inferred(k_crust(g, 4, corenum=corenum)) == [1:21;]
         end
-
     end
 
     # TODO k_corona does not work yet with generic graphs

--- a/test/edit_distance.jl
+++ b/test/edit_distance.jl
@@ -14,7 +14,9 @@
     edge_delete_cost = e -> 5.0
     edge_subst_cost = (e1, e2) -> 6.0
 
-    @testset "undirected edit_distance" for G1 in test_generic_graphs(g1), G2 in test_generic_graphs(g2)
+    @testset "undirected edit_distance" for G1 in test_generic_graphs(g1),
+        G2 in test_generic_graphs(g2)
+
         d, λ = @inferred(edit_distance(G1, G2))
         @test d == 2.0
         d, λ = @inferred(
@@ -44,7 +46,9 @@
         add_edge!(g2, e)
     end
 
-    @testset "directed edit_distance" for G1 in test_generic_graphs(g1), G2 in test_generic_graphs(g2)
+    @testset "directed edit_distance" for G1 in test_generic_graphs(g1),
+        G2 in test_generic_graphs(g2)
+
         d, λ = @inferred(edit_distance(G1, G2))
         @test d == 4.0
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,9 @@ end
 @testset "Code quality (JET.jl)" begin
     if VERSION >= v"1.9"
         @assert get_pkg_version("JET") >= v"0.8.4"
-        JET.test_package(Graphs; target_defined_modules=true, ignore_missing_comparison=true)
+        JET.test_package(
+            Graphs; target_defined_modules=true, ignore_missing_comparison=true
+        )
     end
 end
 
@@ -40,7 +42,7 @@ end
 end
 
 @testset verbose = true "Code formatting (JuliaFormatter.jl)" begin
-    @test format(Graphs; verbose=false, overwrite=false, ignore="vf2.jl")  # TODO: remove ignore kwarg once the file is formatted correctly
+    @test format(Graphs; verbose=false, overwrite=false)
 end
 
 doctest(Graphs)
@@ -70,7 +72,7 @@ function test_generic_graphs(g; eltypes=[UInt8, Int16], skip_if_too_large::Bool=
     SG = is_directed(g) ? SimpleDiGraph : SimpleGraph
     GG = is_directed(g) ? GenericDiGraph : GenericGraph
     result = GG[]
-    for T in  eltypes
+    for T in eltypes
         if skip_if_too_large && nv(g) > typemax(T)
             continue
         end
@@ -79,10 +81,15 @@ function test_generic_graphs(g; eltypes=[UInt8, Int16], skip_if_too_large::Bool=
     return result
 end
 
-test_generic_graphs(gs...; kwargs...) = vcat((test_generic_graphs(g; kwargs...) for g in gs)...)
+function test_generic_graphs(gs...; kwargs...)
+    return vcat((test_generic_graphs(g; kwargs...) for g in gs)...)
+end
 
-test_large_generic_graphs(g; skip_if_too_large::Bool=false) = test_generic_graphs(g; eltypes=[UInt16, Int32], skip_if_too_large=skip_if_too_large)
-
+function test_large_generic_graphs(g; skip_if_too_large::Bool=false)
+    return test_generic_graphs(
+        g; eltypes=[UInt16, Int32], skip_if_too_large=skip_if_too_large
+    )
+end
 
 tests = [
     "simplegraphs/runtests",

--- a/test/shortestpaths/astar.jl
+++ b/test/shortestpaths/astar.jl
@@ -10,7 +10,10 @@
             @inferred(a_star(g, 1, 4, d2))
         @test isempty(@inferred(a_star(dg, 4, 1)))
     end
-    @testset "GenericGraph and GenricDiGraph with SimpleEdge" for g in test_generic_graphs(g3), dg in test_generic_graphs(g4)
+    @testset "GenericGraph and GenricDiGraph with SimpleEdge" for g in
+                                                                  test_generic_graphs(g3),
+        dg in test_generic_graphs(g4)
+
         zero_heuristic = n -> 0
         Eg = SimpleEdge{eltype(g)}
         Edg = SimpleEdge{eltype(dg)}
@@ -30,5 +33,6 @@
         s::Int
         d::Int
     end
-    @test eltype(a_star(GenericGraph(g), 1, 4, w, n -> 0, MyFavoriteEdgeType)) == MyFavoriteEdgeType
+    @test eltype(a_star(GenericGraph(g), 1, 4, w, n -> 0, MyFavoriteEdgeType)) ==
+        MyFavoriteEdgeType
 end

--- a/test/shortestpaths/dijkstra.jl
+++ b/test/shortestpaths/dijkstra.jl
@@ -103,12 +103,14 @@
     end
 
     #maximum distance setting limits paths found
-        G = cycle_graph(6)
-        add_edge!(G, 1, 3)
-        m = float([0 2 2 0 0 1; 2 0 1 0 0 0; 2 1 0 4 0 0; 0 0 4 0 1 0; 0 0 0 1 0 1; 1 0 0 0 1 0])
+    G = cycle_graph(6)
+    add_edge!(G, 1, 3)
+    m = float(
+        [0 2 2 0 0 1; 2 0 1 0 0 0; 2 1 0 4 0 0; 0 0 4 0 1 0; 0 0 0 1 0 1; 1 0 0 0 1 0]
+    )
 
-        for g in test_generic_graphs(G)
-            ds = @inferred(dijkstra_shortest_paths(g, 3, m;maxdist=3.0))
-            @test ds.dists == [2, 1, 0, Inf, Inf, 3]
-        end
+    for g in test_generic_graphs(G)
+        ds = @inferred(dijkstra_shortest_paths(g, 3, m; maxdist=3.0))
+        @test ds.dists == [2, 1, 0, Inf, Inf, 3]
+    end
 end

--- a/test/shortestpaths/yen.jl
+++ b/test/shortestpaths/yen.jl
@@ -113,16 +113,16 @@
     w[1, 4] = 3
     w[4, 1] = 3
     for g in testdigraphs(G)
-         ds = @inferred(yen_k_shortest_paths(g, 1, 6, w, 100))
+        ds = @inferred(yen_k_shortest_paths(g, 1, 6, w, 100))
         @test ds.dists == [4.0, 5.0, 7.0, 7.0, 8.0, 8.0, 8.0, 11.0, 11.0]
-    
-        ds = @inferred(yen_k_shortest_paths(g, 1, 6, w, 100, maxdist=7.))
-        @test ds.dists == [4.0, 5.0, 7.0, 7.0]
-     end
 
-     # Test that no paths are returned if every path is longer than maxdist
+        ds = @inferred(yen_k_shortest_paths(g, 1, 6, w, 100, maxdist=7.0))
+        @test ds.dists == [4.0, 5.0, 7.0, 7.0]
+    end
+
+    # Test that no paths are returned if every path is longer than maxdist
     for g in testdigraphs(cycle_digraph(10))
         ds = @inferred(yen_k_shortest_paths(g, 2, 1, weights(g), 2, maxdist=2))
         @test isempty(ds.paths)
-     end
+    end
 end

--- a/test/simplegraphs/simpleedge.jl
+++ b/test/simplegraphs/simpleedge.jl
@@ -37,7 +37,7 @@
     end
 
     @testset "comparison" begin
-        @test SimpleEdge(1, 2) < SimpleEdge(1, 3) 
+        @test SimpleEdge(1, 2) < SimpleEdge(1, 3)
         @test SimpleEdge(1, 2) < SimpleEdge(2, 3)
         @test SimpleEdge(1, 2) < SimpleEdge(2, 1)
         @test SimpleEdge(1, 2) <= SimpleEdge(1, 2)

--- a/test/traversals/dfs.jl
+++ b/test/traversals/dfs.jl
@@ -31,7 +31,7 @@
     add_edge!(g6, 4, 3)
     g7 = copy(g6)
     add_edge!(g7, 3, 4)
-    
+
     @testset "dfs_tree" begin
         for g in testdigraphs(g5)
             z = @inferred(dfs_tree(GenericDiGraph(g), 1))

--- a/test/traversals/eulerian.jl
+++ b/test/traversals/eulerian.jl
@@ -1,36 +1,68 @@
 @testset "Eulerian tours/cycles" begin
     # a cycle (identical start/end)
-    g0 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,1)]))
+    g0 = GenericGraph(SimpleGraph([Edge(1, 2), Edge(2, 3), Edge(3, 1)]))
     @test eulerian(g0, 1) == eulerian(g0)
     @test last(eulerian(g0, 1)) == 1 # a cycle
 
     # a tour (different start/end)
-    g1 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,4)]))
-    @test eulerian(g1, 1) == [1,2,3,4]
-    @test_throws ErrorException("starting vertex has even degree but there are other vertices with odd degree: a eulerian cycle does not exist") eulerian(g1, 2)
-    
+    g1 = GenericGraph(SimpleGraph([Edge(1, 2), Edge(2, 3), Edge(3, 4)]))
+    @test eulerian(g1, 1) == [1, 2, 3, 4]
+    @test_throws ErrorException(
+        "starting vertex has even degree but there are other vertices with odd degree: a eulerian cycle does not exist",
+    ) eulerian(g1, 2)
+
     # a cycle with a node (vertex 2) with multiple neighbors
-    g2 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,4), Edge(4,1), Edge(2,5), Edge(5,6), Edge(6,2)]))
+    g2 = GenericGraph(
+        SimpleGraph([
+            Edge(1, 2),
+            Edge(2, 3),
+            Edge(3, 4),
+            Edge(4, 1),
+            Edge(2, 5),
+            Edge(5, 6),
+            Edge(6, 2),
+        ]),
+    )
     @test eulerian(g2) == eulerian(g2, 1) == [1, 2, 5, 6, 2, 3, 4, 1]
 
     # graph with odd-degree vertices
-    g3 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,4), Edge(2,4), Edge(4,1), Edge(4,2)]))
-    @test_throws ErrorException("starting vertex has even degree but there are other vertices with odd degree: a eulerian cycle does not exist") eulerian(g3, 1)
+    g3 = GenericGraph(
+        SimpleGraph([
+            Edge(1, 2), Edge(2, 3), Edge(3, 4), Edge(2, 4), Edge(4, 1), Edge(4, 2)
+        ]),
+    )
+    @test_throws ErrorException(
+        "starting vertex has even degree but there are other vertices with odd degree: a eulerian cycle does not exist",
+    ) eulerian(g3, 1)
 
     # start/end point not in graph
     @test_throws ErrorException("starting vertex is not in the graph") eulerian(g3, 5)
 
     # disconnected components
-    g4 = GenericGraph(SimpleGraph([Edge(1,2), Edge(2,3), Edge(3,1),  # component 1
-                      Edge(4,5), Edge(5,6), Edge(6,4)])) # component 2
-    @test_throws ErrorException("graph is not connected: a eulerian cycle/trail does not exist") eulerian(g4)
+    g4 = GenericGraph(
+        SimpleGraph([
+            Edge(1, 2),
+            Edge(2, 3),
+            Edge(3, 1),  # component 1
+            Edge(4, 5),
+            Edge(5, 6),
+            Edge(6, 4),
+        ]),
+    ) # component 2
+    @test_throws ErrorException(
+        "graph is not connected: a eulerian cycle/trail does not exist"
+    ) eulerian(g4)
 
     # zero-degree nodes
     g5′ = SimpleGraph(4)
-    add_edge!(g5′, Edge(1,2)); add_edge!(g5′, Edge(2,3)); add_edge!(g5′, Edge(3,1))
+    add_edge!(g5′, Edge(1, 2))
+    add_edge!(g5′, Edge(2, 3))
+    add_edge!(g5′, Edge(3, 1))
     g5 = GenericGraph(g5′)
-    @test_throws ErrorException("some vertices have degree zero (are isolated) and cannot be reached") eulerian(g5)
+    @test_throws ErrorException(
+        "some vertices have degree zero (are isolated) and cannot be reached"
+    ) eulerian(g5)
 
     # not yet implemented for directed graphs
-    @test_broken eulerian(GenericDiGraph([Edge(1,2), Edge(2,3), Edge(3,1)]))
+    @test_broken eulerian(GenericDiGraph([Edge(1, 2), Edge(2, 3), Edge(3, 1)]))
 end

--- a/test/traversals/maxadjvisit.jl
+++ b/test/traversals/maxadjvisit.jl
@@ -78,6 +78,6 @@
     @test parity == [1, 1, 1, 1, 2, 2, 2, 2]
     @test bestcut == 6
 
-    w[6,7] = -1
+    w[6, 7] = -1
     @test_throws DomainError mincut(g, w)
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -84,7 +84,6 @@ end
 end
 
 @testset "collect_if_not_vector" begin
-
     vectors = [["ab", "cd"], 1:2:9, BitVector([0, 1, 0])]
     not_vectors = [Set([1, 2]), (x for x in Int8[3, 4]), "xyz"]
 


### PR DESCRIPTION
PR #190 introduced a BlueStyle formatting check, but back then the file `src/Experimental/vf2.jl` caused problems to JuliaFormatter. So it was ignored as follows: `format(Graphs; ignore=["vf2.jl"])`.

Some time later, PR #210 changed this to `format(Graphs; ignore="vf2.jl")`, which seems to also have ignored a lot of other files. The reasons are a bit unclear to me.

I checked again, and now JuliaFormatter can handle `src/Experimental/vf2.jl` without erroring. I removed the `ignore` keyword in the test, and reformatted all the files that had been overlooked since #210.

The only meaningful changes are in `test/runtests.jl` and `src/Experimental/vf2.jl`, the rest is just JuliaFormatter doing its thing.