### PR TITLE
fix mincut()

### DIFF
--- a/src/traversals/maxadjvisit.jl
+++ b/src/traversals/maxadjvisit.jl
@@ -106,7 +106,7 @@ function _merge_vertex!(merged_vertices, fadjlist, is_merged, w, u, v)
         w[v2, root] = w[root, v2]
     end
     # update neighbors
-    fadjlist[root] = union(fadjlist[root], fadjlist[non_root])
+    union!(fadjlist[root], fadjlist[non_root])
     for v in fadjlist[non_root]
         if root ∉ fadjlist[v]
             push!(fadjlist[v], root)

--- a/src/traversals/maxadjvisit.jl
+++ b/src/traversals/maxadjvisit.jl
@@ -64,8 +64,7 @@ assumed to be 1.
         local cutweight
         while true
             last_vertex = u
-            u, cutweight = first(pq)
-            dequeue!(pq)
+            u, cutweight = dequeue_pair!(pq)
             isempty(pq) && break
             for v in fadjlist[u]
                 (is_processed[v] || is_merged[v] || u == v) && continue

--- a/src/traversals/maxadjvisit.jl
+++ b/src/traversals/maxadjvisit.jl
@@ -63,6 +63,7 @@ assumed to be 1.
             cutweight += w[u, v]
         end
         # Minimum cut phase
+        local adj_cost
         while true
             last_vertex = u
             u, adj_cost = first(pq)
@@ -89,6 +90,8 @@ assumed to be 1.
                 graph_size -= 1
             end
         end
+
+        cutweight = adj_cost
 
         # check if we improved the mincut
         if cutweight < bestweight

--- a/src/traversals/maxadjvisit.jl
+++ b/src/traversals/maxadjvisit.jl
@@ -75,7 +75,7 @@ assumed to be 1.
             # encountered, so if cutweight >= bestweight, we can already merge these
             # vertices to save one phase.
             if cutweight >= bestweight
-                _merge_vertex!(merged_vertices, fadjlist, is_merged, w, u, last_vertex)
+                u = _merge_vertex!(merged_vertices, fadjlist, is_merged, w, u, last_vertex)
                 graph_size -= 1
             end
         end
@@ -89,9 +89,8 @@ assumed to be 1.
         end
 
         # merge u and last_vertex
-        root = _merge_vertex!(merged_vertices, fadjlist, is_merged, w, u, last_vertex)
+        u = _merge_vertex!(merged_vertices, fadjlist, is_merged, w, u, last_vertex)
         graph_size -= 1
-        u = root # we are sure this vertex was not merged, so the next phase start from it
     end
     return (convert(Vector{Int8}, parities) .+ one(Int8), bestweight)
 end

--- a/src/traversals/maxadjvisit.jl
+++ b/src/traversals/maxadjvisit.jl
@@ -25,6 +25,9 @@ assumed to be 1.
     # in which case we'll return immediately.
     (nvg > one(U)) || return (Vector{Int8}([1]), zero(T))
 
+    # to avoid reallocating lists in fadjlist, we have some already merged vertices
+    # still appearing in fadjlist. When iterating neighbors, is_merged makes sure we
+    # don't consider them
     is_merged = falses(nvg)
     merged_vertices = IntDisjointSets(U(nvg))
     graph_size = nvg
@@ -96,6 +99,7 @@ assumed to be 1.
 end
 
 function _merge_vertex!(merged_vertices, fadjlist, is_merged, w, u, v)
+    # root is kept, non-root is discarded
     root = union!(merged_vertices, u, v)
     non_root = (root == u) ? v : u
     is_merged[non_root] = true


### PR DESCRIPTION
To my understanding `adj_cost` stores the cut weight between the last two vertices, s and t.
If that is lower then the current best cut it becomes the new best.

I do not really understand the `cutweight` computation inside the mincut phase. (It reminds me more of a flow computation) but also didn't think hard enough about the new intermediate pruning.

Anyways, with this change I get the correct cut for the AoC graph (c.f. #324).
I did not test this any further, so please someone knowledgable look into it before merge

