### PR TITLE
Added types and note to `erdos_renyi` function

### DIFF
--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -127,7 +127,7 @@ function randbn(
 end
 
 """
-    erdos_renyi(n, p)
+    erdos_renyi(n, p::Real)
 
 Create an [Erdős–Rényi](http://en.wikipedia.org/wiki/Erdős–Rényi_model)
 random graph with `n` vertices. Edges are added between pairs of vertices with
@@ -170,7 +170,7 @@ function erdos_renyi(
 end
 
 """
-    erdos_renyi(n, ne)
+    erdos_renyi(n, ne::Integer)
 
 Create an [Erdős–Rényi](http://en.wikipedia.org/wiki/Erdős–Rényi_model) random
 graph with `n` vertices and `ne` edges.

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -131,7 +131,12 @@ end
 
 Create an [Erdős–Rényi](http://en.wikipedia.org/wiki/Erdős–Rényi_model)
 random graph with `n` vertices. Edges are added between pairs of vertices with
-probability `p`.
+probability `p`. 
+
+Note that there exists another definition of the Erdös-Rényi model in which the
+total number of edges is kept constant, rather than the probability `p`.
+To access this definition, use `erdos_renyi(n, ne::Integer)`
+(specifically: `erdos_renyi(n, 1) != erdos_renyi(n, 1.0)`).
 
 ### Optional Arguments
 - `is_directed=false`: if true, return a directed graph.


### PR DESCRIPTION
I added typed-definitions to the docstring of `erdos_renyi`, as we differentiate the two different definitions of the Erdös-Rényi ensemble by dispatching on the type of the second argument.

As I spent some time with the strange edge case of `erdos_renyi(n, 1) != erdos_renyi(n , 1.0)` today this feels like a good idea.