### PR TITLE
All simple paths (refresh #20)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Graphs"
 uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-version = "1.9.0"
+version = "1.9.1"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Graphs"
 uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-version = "1.9.1"
+version = "1.10.0"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"

--- a/docs/src/algorithms/traversals.md
+++ b/docs/src/algorithms/traversals.md
@@ -21,5 +21,6 @@ Pages   = [
     "traversals/maxadjvisit.jl",
     "traversals/randomwalks.jl",
     "traversals/eulerian.jl",
+    "traversals/all_simple_paths.jl",
 ]
 ```

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -23,7 +23,8 @@ using DataStructures:
     union!,
     find_root!,
     BinaryMaxHeap,
-    BinaryMinHeap
+    BinaryMinHeap,
+    Stack
 using LinearAlgebra: I, Symmetric, diagm, eigen, eigvals, norm, rmul!, tril, triu
 import LinearAlgebra: Diagonal, issymmetric, mul!
 using Random:
@@ -196,6 +197,9 @@ export
 
     # eulerian
     eulerian,
+    
+    # all simple paths
+    all_simple_paths,
 
     # coloring
     greedy_color,
@@ -496,6 +500,7 @@ include("traversals/maxadjvisit.jl")
 include("traversals/randomwalks.jl")
 include("traversals/diffusion.jl")
 include("traversals/eulerian.jl")
+include("traversals/all_simple_paths.jl")
 include("connectivity.jl")
 include("distance.jl")
 include("editdist.jl")

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -197,7 +197,7 @@ export
 
     # eulerian
     eulerian,
-    
+
     # all simple paths
     all_simple_paths,
 

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -1,6 +1,6 @@
 """
     all_simple_paths(g, u, v; cutoff=nv(g)) --> Graphs.SimplePathIterator
-    
+
 Returns an iterator that generates all simple paths in the graph `g` from a source vertex
 `u` to a target vertex `v` or iterable of target vertices `vs`.
 
@@ -13,30 +13,32 @@ The maximum path length (i.e., number of edges) is limited by the keyword argume
 omitted.
 
 ## Examples
-```jldoctest
-julia> using Graphs
-julia> g = complete_graph(4)
+```jldoctest allsimplepaths; setup = :(using Graphs)
+julia> g = complete_graph(4);
+
 julia> spi = all_simple_paths(g, 1, 4)
- Graphs.SimplePathIterator(1 → 4)
+SimplePathIterator{SimpleGraph{Int64}}(1 → 4)
+
 julia> collect(spi)
 5-element Vector{Vector{Int64}}:
- [1, 4]
- [1, 3, 4]
- [1, 3, 2, 4]
- [1, 2, 4]
  [1, 2, 3, 4]
+ [1, 2, 4]
+ [1, 3, 2, 4]
+ [1, 3, 4]
+ [1, 4]
 ```
 We can restrict the search to paths of length less than a specified cut-off (here, 2 edges):
-```jldoctest
+```jldoctest allsimplepaths; setup = :(using Graphs)
 julia> collect(all_simple_paths(g, 1, 4; cutoff=2))
+3-element Vector{Vector{Int64}}:
  [1, 2, 4]
  [1, 3, 4]
  [1, 4]
 ```
 """
 function all_simple_paths(
-            g::AbstractGraph{T}, 
-            u::T, 
+            g::AbstractGraph{T},
+            u::T,
             vs;
             cutoff::T=nv(g)
             ) where T <: Integer
@@ -99,7 +101,7 @@ end
 Returns the next simple path in `spi`, according to a depth-first search.
 """
 function Base.iterate(
-            spi::SimplePathIterator{T}, 
+            spi::SimplePathIterator{T},
             state::SimplePathIteratorState=SimplePathIteratorState(spi)
             ) where T <: Integer
 
@@ -121,7 +123,7 @@ function Base.iterate(
             continue
         end
 
-        child = children[next_childe_index]    
+        child = children[next_childe_index]
         first(state.stack)[2] += 1 # move child index forward
         child in state.visited && continue
 

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -117,7 +117,7 @@ function Base.iterate(
 
         child = children[next_child_index]
         next_child_index′ = pop!(state.stack)[2]                 # move child index forward
-        push!(state.stack, (parent_node, next_child_index′ + 1)) # ↩
+        push!(state.stack, (parent_node, next_child_index′ + one(T))) # ↩
         child in state.visited && continue
 
         if length(state.visited) == spi.cutoff

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -1,8 +1,10 @@
 """
     all_simple_paths(g, u, v; cutoff=nv(g)) --> Graphs.SimplePathIterator
 
-Returns an iterator that generates all simple paths in the graph `g` from a source vertex
-`u` to a target vertex `v` or iterable of target vertices `vs`.
+Returns an iterator that generates all 
+[simple paths](https://en.wikipedia.org/wiki/Path_(graph_theory)#Walk,_trail,_and_path) in 
+the graph `g` from a source vertex `u` to a target vertex `v` or iterable of target vertices
+`vs`. A simple path has no repeated vertices.
 
 The iterator's elements (i.e., the paths) can be materialized via `collect` or `iterate`.
 Paths are iterated in the order of a depth-first search.

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -15,7 +15,7 @@ zero-length path `[u]` is included among the iterates.
 
 ## Keyword arguments
 The maximum path length (i.e., number of edges) is limited by the keyword argument `cutoff`
-(default, `nv(g)-1`). If a path's path length is greater than or equal to `cutoff`, it is
+(default, `nv(g)-1`). If a path's path length is greater than `cutoff`, it is
 omitted.
 
 ## Examples
@@ -33,7 +33,7 @@ julia> collect(spi)
  [1, 3, 4]
  [1, 4]
 ```
-We can restrict the search to paths of length less than a specified cut-off (here, 2 edges):
+We can restrict the search to paths of length less than or equal to a specified cut-off (here, 2 edges):
 ```jldoctest allsimplepaths; setup = :(using Graphs)
 julia> collect(all_simple_paths(g, 1, 4; cutoff=2))
 3-element Vector{Vector{Int64}}:

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -84,7 +84,7 @@ function SimplePathIteratorState(spi::SimplePathIterator{T}) where {T<:Integer}
     visited = Stack{T}()
     queued = Vector{T}()
     push!(visited, spi.u)    # add a starting vertex to the path candidate
-    push!(stack, (spi.u, 1)) # add a child node with index 1
+    push!(stack, (spi.u, one(T))) # add a child node with index 1
     return SimplePathIteratorState{T}(stack, visited, queued, false)
 end
 

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -40,14 +40,13 @@ julia> collect(all_simple_paths(g, 1, 4; cutoff=2))
 ```
 """
 function all_simple_paths(
-    g::AbstractGraph{T}, u::T, vs; cutoff::T=nv(g)-1
+    g::AbstractGraph{T}, u::T, vs; cutoff::T=nv(g) - 1
 ) where {T<:Integer}
     vs = vs isa Set{T} ? vs : Set{T}(vs)
     return SimplePathIterator(g, u, vs, cutoff)
 end
 
-# Iterator that generates all simple paths in `g` from `u` to `vs` of a length at most
-# `cutoff`.
+# iterator over all simple paths from `u` to `vs` in `g` of length less than `cutoff`
 struct SimplePathIterator{T<:Integer,G<:AbstractGraph{T}}
     g::G
     u::T       # start vertex
@@ -71,13 +70,13 @@ Base.IteratorSize(::Type{<:SimplePathIterator}) = Base.SizeUnknown()
 Base.eltype(::SimplePathIterator{T}) where {T} = Vector{T}
 
 mutable struct SimplePathIteratorState{T<:Integer}
-    stack::Stack{Tuple{T, T}} # used to restore iteration of child vertices: elements are
+    stack::Stack{Tuple{T,T}} # used to restore iteration of child vertices: elements are
     # (parent vertex, index of children)
-    visited::Stack{T}       # current path candidate
-    queued::Vector{T}       # remaining targets if path length reached cutoff
+    visited::Stack{T}         # current path candidate
+    queued::Vector{T}         # remaining targets if path length reached cutoff
 end
 function SimplePathIteratorState(spi::SimplePathIterator{T}) where {T<:Integer}
-    stack = Stack{Tuple{T, T}}()
+    stack = Stack{Tuple{T,T}}()
     visited = Stack{T}()
     queued = Vector{T}()
     push!(visited, spi.u)    # add a starting vertex to the path candidate
@@ -91,7 +90,7 @@ function _stepback!(state::SimplePathIteratorState) # updates iterator state.
     return nothing
 end
 
-# Returns the next simple path in `spi`, according to a depth-first search
+# iterates to the next simple path in `spi`, according to a depth-first search
 function Base.iterate(
     spi::SimplePathIterator{T}, state::SimplePathIteratorState=SimplePathIteratorState(spi)
 ) where {T<:Integer}
@@ -108,14 +107,13 @@ function Base.iterate(
         parent_node, next_child_index = first(state.stack)
         children = outneighbors(spi.g, parent_node)
         if length(children) < next_child_index
-            # all children have been checked, step back.
-            _stepback!(state)
+            _stepback!(state) # all children have been checked, step back
             continue
         end
 
         child = children[next_child_index]
-        next_child_index′ = pop!(state.stack)[2]                # move child index forward
-        push!(state.stack, (parent_node, next_child_index′+1))  # ↩
+        next_child_index′ = pop!(state.stack)[2]               # move child index forward
+        push!(state.stack, (parent_node, next_child_index′ + 1)) # ↩
         child in state.visited && continue
 
         if length(state.visited) == spi.cutoff

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -43,12 +43,8 @@ function all_simple_paths(g::AbstractGraph{T}, u::T, vs; cutoff::T=nv(g)) where 
     return SimplePathIterator(g, u, vs, cutoff)
 end
 
-"""
-    SimplePathIterator{T <: Integer}
-
-Iterator that generates all simple paths in `g` from `u` to `vs` of a length at most
-`cutoff`.
-"""
+# Iterator that generates all simple paths in `g` from `u` to `vs` of a length at most
+# `cutoff`.
 struct SimplePathIterator{T<:Integer,G<:AbstractGraph{T}}
     g::G
     u::T       # start vertex
@@ -92,11 +88,7 @@ function _stepback!(state::SimplePathIteratorState) # updates iterator state.
     return nothing
 end
 
-"""
-    Base.iterate(spi::SimplePathIterator{T}, state=nothing)
-
-Returns the next simple path in `spi`, according to a depth-first search.
-"""
+# Returns the next simple path in `spi`, according to a depth-first search
 function Base.iterate(
     spi::SimplePathIterator{T}, state::SimplePathIteratorState=SimplePathIteratorState(spi)
 ) where {T<:Integer}

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -140,7 +140,7 @@ function Base.iterate(
             # update state variables
             push!(state.visited, child) # move to child vertex
             if !isempty(setdiff(spi.vs, state.visited)) # expand stack until all targets are found
-                push!(state.stack, (child, 1)) # add the child node as a parent for next iteration
+                push!(state.stack, (child, one(T))) # add the child node as a parent for next iteration
             else
                 pop!(state.visited) # step back and explore the remaining child nodes
             end

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -1,0 +1,156 @@
+"""
+    all_simple_paths(g, u, v; cutoff=nv(g)) --> Graphs.SimplePathIterator
+    
+Returns an iterator that generates all simple paths in the graph `g` from a source vertex
+`u` to a target vertex `v` or iterable of target vertices `vs`.
+
+The iterator's elements (i.e., the paths) can be materialized via `collect` or `iterate`.
+Paths are iterated in the order of a depth-first search.
+
+## Keyword arguments
+The maximum path length (i.e., number of edges) is limited by the keyword argument `cutoff`
+(default, `nv(g)`). If a path's path length is greater than or equal to `cutoff`, it is
+omitted.
+
+## Examples
+```jldoctest
+julia> using Graphs
+julia> g = complete_graph(4)
+julia> spi = all_simple_paths(g, 1, 4)
+ Graphs.SimplePathIterator(1 → 4)
+julia> collect(spi)
+5-element Vector{Vector{Int64}}:
+ [1, 4]
+ [1, 3, 4]
+ [1, 3, 2, 4]
+ [1, 2, 4]
+ [1, 2, 3, 4]
+```
+We can restrict the search to paths of length less than a specified cut-off (here, 2 edges):
+```jldoctest
+julia> collect(all_simple_paths(g, 1, 4; cutoff=2))
+ [1, 2, 4]
+ [1, 3, 4]
+ [1, 4]
+```
+"""
+function all_simple_paths(
+            g::AbstractGraph{T}, 
+            u::T, 
+            vs;
+            cutoff::T=nv(g)
+            ) where T <: Integer
+
+    vs = vs isa Set{T} ? vs : Set{T}(vs)
+    return SimplePathIterator(g, u, vs, cutoff)
+end
+
+"""
+    SimplePathIterator{T <: Integer}
+
+Iterator that generates all simple paths in `g` from `u` to `vs` of a length at most
+`cutoff`.
+"""
+struct SimplePathIterator{T <: Integer, G <: AbstractGraph{T}}
+    g::G
+    u::T       # start vertex
+    vs::Set{T} # target vertices
+    cutoff::T  # max length of resulting paths
+end
+
+function Base.show(io::IO, spi::SimplePathIterator)
+    print(io, "SimplePathIterator{", typeof(spi.g), "}(", spi.u, " → ")
+    if length(spi.vs) == 1
+        print(io, only(spi.vs))
+    else
+        print(io, '[')
+        join(io, spi.vs, ", ")
+        print(io, ']')
+    end
+    print(io, ')')
+end
+Base.IteratorSize(::Type{<:SimplePathIterator}) = Base.SizeUnknown()
+Base.eltype(::SimplePathIterator{T}) where T = Vector{T}
+
+mutable struct SimplePathIteratorState{T <: Integer}
+    stack::Stack{Vector{T}} # used to restore iteration of child vertices; each vector has
+                            # two elements: a parent vertex and an index of children
+    visited::Stack{T}       # current path candidate
+    queued::Vector{T}       # remaining targets if path length reached cutoff
+end
+function SimplePathIteratorState(spi::SimplePathIterator{T}) where T <: Integer
+    stack = Stack{Vector{T}}()
+    visited = Stack{T}()
+    queued = Vector{T}()
+    push!(visited, spi.u)    # add a starting vertex to the path candidate
+    push!(stack, [spi.u, 1]) # add a child node with index 1
+    SimplePathIteratorState{T}(stack, visited, queued)
+end
+
+function _stepback!(state::SimplePathIteratorState) # updates iterator state.
+    pop!(state.stack)
+    pop!(state.visited)
+end
+
+
+"""
+    Base.iterate(spi::SimplePathIterator{T}, state=nothing)
+
+Returns the next simple path in `spi`, according to a depth-first search.
+"""
+function Base.iterate(
+            spi::SimplePathIterator{T}, 
+            state::SimplePathIteratorState=SimplePathIteratorState(spi)
+            ) where T <: Integer
+
+    while !isempty(state.stack)
+        if !isempty(state.queued) # consume queued targets
+            target = pop!(state.queued)
+            result = vcat(reverse(collect(state.visited)), target)
+            if isempty(state.queued)
+                _stepback!(state)
+            end
+            return result, state
+        end
+
+        parent_node, next_childe_index = first(state.stack)
+        children = outneighbors(spi.g, parent_node)
+        if length(children) < next_childe_index
+            # all children have been checked, step back.
+            _stepback!(state)
+            continue
+        end
+
+        child = children[next_childe_index]    
+        first(state.stack)[2] += 1 # move child index forward
+        child in state.visited && continue
+
+        if length(state.visited) == spi.cutoff
+            # collect adjacent targets if more exist and add them to queue
+            rest_children = Set(children[next_childe_index: end])
+            state.queued = collect(setdiff(intersect(spi.vs, rest_children), Set(state.visited)))
+
+            if isempty(state.queued)
+                _stepback!(state)
+            end
+        else
+            result = if child in spi.vs
+                vcat(reverse(collect(state.visited)), child)
+            else
+                nothing
+            end
+
+            # update state variables
+            push!(state.visited, child) # move to child vertex
+            if !isempty(setdiff(spi.vs, state.visited)) # expand stack until all targets are found
+                push!(state.stack, [child, 1]) # add the child node as a parent for next iteration
+            else
+                pop!(state.visited) # step back and explore the remaining child nodes
+            end
+
+            if !isnothing(result) # found a new path, return it
+                return result, state
+            end
+        end
+    end
+end

--- a/src/traversals/all_simple_paths.jl
+++ b/src/traversals/all_simple_paths.jl
@@ -33,7 +33,8 @@ julia> collect(spi)
  [1, 3, 4]
  [1, 4]
 ```
-We can restrict the search to paths of length less than or equal to a specified cut-off (here, 2 edges):
+We can restrict the search to path lengths less than or equal to a specified cut-off (here, 
+2 edges):
 ```jldoctest allsimplepaths; setup = :(using Graphs)
 julia> collect(all_simple_paths(g, 1, 4; cutoff=2))
 3-element Vector{Vector{Int64}}:
@@ -43,7 +44,7 @@ julia> collect(all_simple_paths(g, 1, 4; cutoff=2))
 ```
 """
 function all_simple_paths(
-    g::AbstractGraph{T}, u::T, vs; cutoff::T=nv(g) - 1
+    g::AbstractGraph{T}, u::T, vs; cutoff::T=nv(g) - one(T)
 ) where {T<:Integer}
     vs = vs isa Set{T} ? vs : Set{T}(vs)
     return SimplePathIterator(g, u, vs, cutoff)
@@ -73,7 +74,7 @@ Base.IteratorSize(::Type{<:SimplePathIterator}) = Base.SizeUnknown()
 Base.eltype(::SimplePathIterator{T}) where {T} = Vector{T}
 
 mutable struct SimplePathIteratorState{T<:Integer}
-    stack::Stack{Tuple{T,T}} # used to restore iteration of child vertices: elements are
+    stack::Stack{Tuple{T,T}} # used to restore iteration of child vertices: elements are ↩
     # (parent vertex, index of children)
     visited::Stack{T}         # current path candidate
     queued::Vector{T}         # remaining targets if path length reached cutoff
@@ -116,8 +117,8 @@ function Base.iterate(
         end
 
         child = children[next_child_index]
-        next_child_index′ = pop!(state.stack)[2]                 # move child index forward
-        push!(state.stack, (parent_node, next_child_index′ + one(T))) # ↩
+        next_child_index_tmp = pop!(state.stack)[2]                      # move child ↩ 
+        push!(state.stack, (parent_node, next_child_index_tmp + one(T))) # index forward
         child in state.visited && continue
 
         if length(state.visited) == spi.cutoff

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,7 @@ tests = [
     "traversals/randomwalks",
     "traversals/diffusion",
     "traversals/eulerian",
+    "traversals/all_simple_paths",
     "community/cliques",
     "community/core-periphery",
     "community/label_propagation",

--- a/test/traversals/all_simple_paths.jl
+++ b/test/traversals/all_simple_paths.jl
@@ -2,7 +2,7 @@
     # single path
     g = path_graph(4)
     paths = all_simple_paths(g, 1, 4)
-    @test Set(paths) == Set(collect(paths)) == Set([[1, 2, 3, 4]]) 
+    @test Set(paths) == Set(collect(paths)) == Set([[1, 2, 3, 4]])
 
     # printing
     @test sprint(show, paths) == "SimplePathIterator{SimpleGraph{Int64}}(1 → 4)"

--- a/test/traversals/all_simple_paths.jl
+++ b/test/traversals/all_simple_paths.jl
@@ -1,0 +1,127 @@
+@testset "All simple paths" begin
+    # single path
+    g = path_graph(4)
+    paths = all_simple_paths(g, 1, 4)
+    @test Set(p for p in paths) == Set([[1, 2, 3, 4]])
+    @test Set(collect(paths)) == Set([[1, 2, 3, 4]])
+    @test 1 == length(paths)
+
+
+    # single path with cutoff
+    @test collect(all_simple_paths(g, 1, 4; cutoff=2)) == [[1, 2, 4], [1, 3, 4], [1, 4]]
+
+    # two paths
+    g = path_graph(4)
+    add_vertex!(g)
+    add_edge!(g, 3, 5)
+    paths = all_simple_paths(g, 1, [4, 5])
+    @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+    @test Set(collect(paths)) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+    @test 2 == length(paths)
+
+    # two paths with cutoff
+    g = path_graph(4)
+    add_vertex!(g)
+    add_edge!(g, 3, 5)
+    paths = all_simple_paths(g, 1, [4, 5], cutoff=3)
+    @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+
+    # two targets in line emits two paths
+    g = path_graph(4)
+    add_vertex!(g)
+    paths = all_simple_paths(g, 1, [3, 4])
+    @test Set(p for p in paths) == Set([[1, 2, 3], [1, 2, 3, 4]])
+
+    # two paths digraph
+    g = SimpleDiGraph(5)
+    add_edge!(g, 1, 2)
+    add_edge!(g, 2, 3)
+    add_edge!(g, 3, 4)
+    add_edge!(g, 3, 5)    
+    paths = all_simple_paths(g, 1, [4, 5])
+    @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+
+    # two paths digraph with cutoff
+    g = SimpleDiGraph(5)
+    add_edge!(g, 1, 2)
+    add_edge!(g, 2, 3)
+    add_edge!(g, 3, 4)
+    add_edge!(g, 3, 5)    
+    paths = all_simple_paths(g, 1, [4, 5], cutoff=3)
+    @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+
+    # digraph with a cycle
+    g = SimpleDiGraph(4)
+    add_edge!(g, 1, 2)
+    add_edge!(g, 2, 3)
+    add_edge!(g, 3, 1)
+    add_edge!(g, 2, 4)
+    paths = all_simple_paths(g, 1, 4)
+    @test Set(p for p in paths) == Set([[1, 2, 4]])
+
+    # digraph with a cycle. paths with two targets share a node in the cycle.
+    g = SimpleDiGraph(4)
+    add_edge!(g, 1, 2)
+    add_edge!(g, 2, 3)
+    add_edge!(g, 3, 1)
+    add_edge!(g, 2, 4)
+    paths = all_simple_paths(g, 1, [3, 4])
+    @test Set(p for p in paths) == Set([[1, 2, 3], [1, 2, 4]])
+
+    # source equals targets
+    g = SimpleGraph(4)
+    paths = all_simple_paths(g, 1, 1)
+    @test Set(p for p in paths) == Set([])
+
+    # cutoff prones paths
+    # Note, a path lenght is node - 1
+    g = complete_graph(4)
+    paths = all_simple_paths(g, 1, 2; cutoff=1)
+    @test Set(p for p in paths) == Set([[1, 2]])
+
+    paths = all_simple_paths(g, 1, 2; cutoff=2)
+    @test Set(p for p in paths) == Set([[1, 2], [1, 3, 2], [1, 4, 2]])
+
+    # non trivial graph
+    g = SimpleDiGraph(6)
+    add_edge!(g, 1, 2)
+    add_edge!(g, 2, 3)
+    add_edge!(g, 3, 4)
+    add_edge!(g, 4, 5)
+
+    add_edge!(g, 1, 6)
+    add_edge!(g, 2, 6)
+    add_edge!(g, 2, 4)
+    add_edge!(g, 6, 5)
+    add_edge!(g, 5, 3)
+    add_edge!(g, 5, 4)
+
+    paths = all_simple_paths(g, 2, [3, 4])
+    @test Set(p for p in paths) == Set([
+         [2, 3],
+         [2, 4, 5, 3],
+         [2, 6, 5, 3],
+         [2, 4],
+         [2, 3, 4],
+         [2, 6, 5, 4],
+         [2, 6, 5, 3, 4],
+    ])
+
+    paths = all_simple_paths(g, 2, [3, 4], cutoff=3)
+    @test Set(p for p in paths) == Set([
+         [2, 3],
+         [2, 4, 5, 3],
+         [2, 6, 5, 3],
+         [2, 4],
+         [2, 3, 4],
+         [2, 6, 5, 4],
+    ])
+
+    paths = all_simple_paths(g, 2, [3, 4], cutoff=2)
+    @test Set(p for p in paths) == Set([
+         [2, 3],
+         [2, 4],
+         [2, 3, 4],
+    ])
+
+end

--- a/test/traversals/all_simple_paths.jl
+++ b/test/traversals/all_simple_paths.jl
@@ -35,7 +35,7 @@
     add_edge!(g, 1, 2)
     add_edge!(g, 2, 3)
     add_edge!(g, 3, 4)
-    add_edge!(g, 3, 5)    
+    add_edge!(g, 3, 5)
     paths = all_simple_paths(g, 1, [4, 5])
     @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
 
@@ -44,7 +44,7 @@
     add_edge!(g, 1, 2)
     add_edge!(g, 2, 3)
     add_edge!(g, 3, 4)
-    add_edge!(g, 3, 5)    
+    add_edge!(g, 3, 5)
     paths = all_simple_paths(g, 1, [4, 5]; cutoff=3)
     @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
 
@@ -96,30 +96,13 @@
 
     paths = all_simple_paths(g, 2, [3, 4])
     @test Set(p for p in paths) == Set([
-         [2, 3],
-         [2, 4, 5, 3],
-         [2, 6, 5, 3],
-         [2, 4],
-         [2, 3, 4],
-         [2, 6, 5, 4],
-         [2, 6, 5, 3, 4],
+        [2, 3], [2, 4, 5, 3], [2, 6, 5, 3], [2, 4], [2, 3, 4], [2, 6, 5, 4], [2, 6, 5, 3, 4]
     ])
 
     paths = all_simple_paths(g, 2, [3, 4]; cutoff=3)
-    @test Set(p for p in paths) == Set([
-         [2, 3],
-         [2, 4, 5, 3],
-         [2, 6, 5, 3],
-         [2, 4],
-         [2, 3, 4],
-         [2, 6, 5, 4],
-    ])
+    @test Set(p for p in paths) ==
+        Set([[2, 3], [2, 4, 5, 3], [2, 6, 5, 3], [2, 4], [2, 3, 4], [2, 6, 5, 4]])
 
     paths = all_simple_paths(g, 2, [3, 4]; cutoff=2)
-    @test Set(p for p in paths) == Set([
-         [2, 3],
-         [2, 4],
-         [2, 3, 4],
-    ])
-
+    @test Set(p for p in paths) == Set([[2, 3], [2, 4], [2, 3, 4]])
 end

--- a/test/traversals/all_simple_paths.jl
+++ b/test/traversals/all_simple_paths.jl
@@ -2,15 +2,14 @@
     # single path
     g = path_graph(4)
     paths = all_simple_paths(g, 1, 4)
-    @test Set(paths) == Set([[1, 2, 3, 4]])
-    @test Set(collect(paths)) == Set([[1, 2, 3, 4]])
+    @test Set(paths) == Set(collect(paths)) == Set([[1, 2, 3, 4]]) 
 
     # printing
     @test sprint(show, paths) == "SimplePathIterator{SimpleGraph{Int64}}(1 → 4)"
 
-    # single path with cutoff
+    # complete graph with cutoff
     g = complete_graph(4)
-    @test collect(all_simple_paths(g, 1, 4; cutoff=2)) == [[1, 2, 4], [1, 3, 4], [1, 4]]
+    @test Set(all_simple_paths(g, 1, 4; cutoff=2)) == Set([[1, 2, 4], [1, 3, 4], [1, 4]])
 
     # two paths
     g = path_graph(4)
@@ -18,14 +17,18 @@
     add_edge!(g, 3, 5)
     paths = all_simple_paths(g, 1, [4, 5])
     @test Set(paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
-    @test Set(collect(paths)) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+    @test Set(collect(paths)) == Set([[1, 2, 3, 4], [1, 2, 3, 5]]) # check `collect` also
 
-    # two paths with cutoff
+    # two paths, with one beyond a cut-off
     g = path_graph(4)
     add_vertex!(g)
     add_edge!(g, 3, 5)
-    paths = all_simple_paths(g, 1, [4, 5]; cutoff=3)
-    @test Set(paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+    add_vertex!(g)
+    add_edge!(g, 5, 6)
+    paths = all_simple_paths(g, 1, [4, 6])
+    @test Set(paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5, 6]])
+    paths = all_simple_paths(g, 1, [4, 6]; cutoff=3)
+    @test Set(paths) == Set([[1, 2, 3, 4]])
 
     # two targets in line emits two paths
     g = path_graph(4)

--- a/test/traversals/all_simple_paths.jl
+++ b/test/traversals/all_simple_paths.jl
@@ -2,8 +2,12 @@
     # single path
     g = path_graph(4)
     paths = all_simple_paths(g, 1, 4)
-    @test Set(p for p in paths) == Set([[1, 2, 3, 4]])
+    @test Set(paths) == Set([[1, 2, 3, 4]])
     @test Set(collect(paths)) == Set([[1, 2, 3, 4]])
+
+    # printing
+    @test sprint(show, paths) == "SimplePathIterator{SimpleGraph{Int64}}(1 → 4)"
+
 
     # single path with cutoff
     g = complete_graph(4)
@@ -14,7 +18,7 @@
     add_vertex!(g)
     add_edge!(g, 3, 5)
     paths = all_simple_paths(g, 1, [4, 5])
-    @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+    @test Set(paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
     @test Set(collect(paths)) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
 
     # two paths with cutoff
@@ -22,13 +26,13 @@
     add_vertex!(g)
     add_edge!(g, 3, 5)
     paths = all_simple_paths(g, 1, [4, 5]; cutoff=3)
-    @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+    @test Set(paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
 
     # two targets in line emits two paths
     g = path_graph(4)
     add_vertex!(g)
     paths = all_simple_paths(g, 1, [3, 4])
-    @test Set(p for p in paths) == Set([[1, 2, 3], [1, 2, 3, 4]])
+    @test Set(paths) == Set([[1, 2, 3], [1, 2, 3, 4]])
 
     # two paths digraph
     g = SimpleDiGraph(5)
@@ -37,7 +41,7 @@
     add_edge!(g, 3, 4)
     add_edge!(g, 3, 5)
     paths = all_simple_paths(g, 1, [4, 5])
-    @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+    @test Set(paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
 
     # two paths digraph with cutoff
     g = SimpleDiGraph(5)
@@ -46,7 +50,7 @@
     add_edge!(g, 3, 4)
     add_edge!(g, 3, 5)
     paths = all_simple_paths(g, 1, [4, 5]; cutoff=3)
-    @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
+    @test Set(paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
 
     # digraph with a cycle
     g = SimpleDiGraph(4)
@@ -55,32 +59,43 @@
     add_edge!(g, 3, 1)
     add_edge!(g, 2, 4)
     paths = all_simple_paths(g, 1, 4)
-    @test Set(p for p in paths) == Set([[1, 2, 4]])
+    @test Set(paths) == Set([[1, 2, 4]])
 
-    # digraph with a cycle. paths with two targets share a node in the cycle.
+    # digraph with a cycle; paths with two targets share a node in the cycle
     g = SimpleDiGraph(4)
     add_edge!(g, 1, 2)
     add_edge!(g, 2, 3)
     add_edge!(g, 3, 1)
     add_edge!(g, 2, 4)
     paths = all_simple_paths(g, 1, [3, 4])
-    @test Set(p for p in paths) == Set([[1, 2, 3], [1, 2, 4]])
+    @test Set(paths) == Set([[1, 2, 3], [1, 2, 4]])
+    
+    # another digraph with a cycle; check cycles are excluded, regardless of cutoff
+    g = SimpleDiGraph(6)
+    add_edge!(g, 1, 2)
+    add_edge!(g, 2, 3)
+    add_edge!(g, 3, 4)
+    add_edge!(g, 4, 5)
+    add_edge!(g, 5, 2)
+    add_edge!(g, 5, 6)
+    paths  = all_simple_paths(g, 1, 6)
+    paths′ = all_simple_paths(g, 1, 6; cutoff=typemax(Int))
+    @test Set(paths) == Set(paths′) == Set([[1, 2, 3, 4, 5, 6]])
 
     # source equals targets
     g = SimpleGraph(4)
     paths = all_simple_paths(g, 1, 1)
-    @test Set(p for p in paths) == Set([])
+    @test Set(paths) == Set{Int}()
 
-    # cutoff prones paths
-    # Note, a path lenght is node - 1
+    # cutoff prunes paths (note: path length is node - 1)
     g = complete_graph(4)
     paths = all_simple_paths(g, 1, 2; cutoff=1)
-    @test Set(p for p in paths) == Set([[1, 2]])
+    @test Set(paths) == Set([[1, 2]])
 
     paths = all_simple_paths(g, 1, 2; cutoff=2)
-    @test Set(p for p in paths) == Set([[1, 2], [1, 3, 2], [1, 4, 2]])
+    @test Set(paths) == Set([[1, 2], [1, 3, 2], [1, 4, 2]])
 
-    # non trivial graph
+    # nontrivial graph
     g = SimpleDiGraph(6)
     add_edge!(g, 1, 2)
     add_edge!(g, 2, 3)
@@ -95,14 +110,14 @@
     add_edge!(g, 5, 4)
 
     paths = all_simple_paths(g, 2, [3, 4])
-    @test Set(p for p in paths) == Set([
+    @test Set(paths) == Set([
         [2, 3], [2, 4, 5, 3], [2, 6, 5, 3], [2, 4], [2, 3, 4], [2, 6, 5, 4], [2, 6, 5, 3, 4]
     ])
 
     paths = all_simple_paths(g, 2, [3, 4]; cutoff=3)
-    @test Set(p for p in paths) ==
+    @test Set(paths) ==
         Set([[2, 3], [2, 4, 5, 3], [2, 6, 5, 3], [2, 4], [2, 3, 4], [2, 6, 5, 4]])
 
     paths = all_simple_paths(g, 2, [3, 4]; cutoff=2)
-    @test Set(p for p in paths) == Set([[2, 3], [2, 4], [2, 3, 4]])
+    @test Set(paths) == Set([[2, 3], [2, 4], [2, 3, 4]])
 end

--- a/test/traversals/all_simple_paths.jl
+++ b/test/traversals/all_simple_paths.jl
@@ -69,7 +69,7 @@
     add_edge!(g, 2, 4)
     paths = all_simple_paths(g, 1, [3, 4])
     @test Set(paths) == Set([[1, 2, 3], [1, 2, 4]])
-    
+
     # another digraph with a cycle; check cycles are excluded, regardless of cutoff
     g = SimpleDiGraph(6)
     add_edge!(g, 1, 2)
@@ -78,7 +78,7 @@
     add_edge!(g, 4, 5)
     add_edge!(g, 5, 2)
     add_edge!(g, 5, 6)
-    paths  = all_simple_paths(g, 1, 6)
+    paths = all_simple_paths(g, 1, 6)
     paths′ = all_simple_paths(g, 1, 6; cutoff=typemax(Int))
     @test Set(paths) == Set(paths′) == Set([[1, 2, 3, 4, 5, 6]])
 

--- a/test/traversals/all_simple_paths.jl
+++ b/test/traversals/all_simple_paths.jl
@@ -8,7 +8,6 @@
     # printing
     @test sprint(show, paths) == "SimplePathIterator{SimpleGraph{Int64}}(1 → 4)"
 
-
     # single path with cutoff
     g = complete_graph(4)
     @test collect(all_simple_paths(g, 1, 4; cutoff=2)) == [[1, 2, 4], [1, 3, 4], [1, 4]]
@@ -82,12 +81,14 @@
     paths′ = all_simple_paths(g, 1, 6; cutoff=typemax(Int))
     @test Set(paths) == Set(paths′) == Set([[1, 2, 3, 4, 5, 6]])
 
-    # source equals targets
-    g = SimpleGraph(4)
-    paths = all_simple_paths(g, 1, 1)
-    @test Set(paths) == Set{Int}()
+    # same source and target vertex
+    g = path_graph(4)
+    @test Set(all_simple_paths(g, 1, 1)) == Set([[1]])
+    @test Set(all_simple_paths(g, 3, 3)) == Set([[3]])
+    @test Set(all_simple_paths(g, 1, [1, 1])) == Set([[1]])
+    @test Set(all_simple_paths(g, 1, [1, 4])) == Set([[1], [1, 2, 3, 4]])
 
-    # cutoff prunes paths (note: path length is node - 1)
+    # cutoff prunes paths (note: maximum path length below is `nv(g) - 1`)
     g = complete_graph(4)
     paths = all_simple_paths(g, 1, 2; cutoff=1)
     @test Set(paths) == Set([[1, 2]])

--- a/test/traversals/all_simple_paths.jl
+++ b/test/traversals/all_simple_paths.jl
@@ -4,10 +4,9 @@
     paths = all_simple_paths(g, 1, 4)
     @test Set(p for p in paths) == Set([[1, 2, 3, 4]])
     @test Set(collect(paths)) == Set([[1, 2, 3, 4]])
-    @test 1 == length(paths)
-
 
     # single path with cutoff
+    g = complete_graph(4)
     @test collect(all_simple_paths(g, 1, 4; cutoff=2)) == [[1, 2, 4], [1, 3, 4], [1, 4]]
 
     # two paths
@@ -17,13 +16,12 @@
     paths = all_simple_paths(g, 1, [4, 5])
     @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
     @test Set(collect(paths)) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
-    @test 2 == length(paths)
 
     # two paths with cutoff
     g = path_graph(4)
     add_vertex!(g)
     add_edge!(g, 3, 5)
-    paths = all_simple_paths(g, 1, [4, 5], cutoff=3)
+    paths = all_simple_paths(g, 1, [4, 5]; cutoff=3)
     @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
 
     # two targets in line emits two paths
@@ -47,7 +45,7 @@
     add_edge!(g, 2, 3)
     add_edge!(g, 3, 4)
     add_edge!(g, 3, 5)    
-    paths = all_simple_paths(g, 1, [4, 5], cutoff=3)
+    paths = all_simple_paths(g, 1, [4, 5]; cutoff=3)
     @test Set(p for p in paths) == Set([[1, 2, 3, 4], [1, 2, 3, 5]])
 
     # digraph with a cycle
@@ -107,7 +105,7 @@
          [2, 6, 5, 3, 4],
     ])
 
-    paths = all_simple_paths(g, 2, [3, 4], cutoff=3)
+    paths = all_simple_paths(g, 2, [3, 4]; cutoff=3)
     @test Set(p for p in paths) == Set([
          [2, 3],
          [2, 4, 5, 3],
@@ -117,7 +115,7 @@
          [2, 6, 5, 4],
     ])
 
-    paths = all_simple_paths(g, 2, [3, 4], cutoff=2)
+    paths = all_simple_paths(g, 2, [3, 4]; cutoff=2)
     @test Set(p for p in paths) == Set([
          [2, 3],
          [2, 4],


### PR DESCRIPTION
This refreshes #20 by @etiennedeg.
(I couldn't figure out how to do it there directly and also didn't want to bother with fixing merge conflicts either)

The original implementation is by @i-aki-y in https://github.com/sbromberger/LightGraphs.jl/pull/1540.

This "refresh" also simplifies the original implementation a bit (to the extent that I understand it), implements the comments/suggestions that were made in #20 (e.g., `cutoff` is now set to `nv(g)`), and improves the documentation (and removes superfluous documentation of internal methods), and removes redundant methods (e.g., the `length` and `collect` implementations; the latter comes from Base, and the former is a performance trap).

Cc. @gdalle cf. Slack conversation about this (and him pointing out the existence of #20).

I suspect there will be some issue from Formatter.jl: but there's no clue as to what's wrong when I run it locally, just that something is wrong.