### PR TITLE
using symbols instead of structures when calling methods from ArnoldiMethod.jl

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -3,7 +3,7 @@ module Graphs
 using SimpleTraits
 
 ### Remove the following line once #915 is closed
-using ArnoldiMethod: LM, SR, LR, partialschur, partialeigen
+using ArnoldiMethod: partialschur, partialeigen
 using Statistics: mean
 
 # Currently used to support the ismutable function that is not available in Julia < v1.7

--- a/src/Parallel/Parallel.jl
+++ b/src/Parallel/Parallel.jl
@@ -5,7 +5,7 @@ using Graphs: sample, AbstractPathState, JohnsonState, BellmanFordState, FloydWa
 using Distributed: @distributed
 using Base.Threads: @threads, nthreads, Atomic, atomic_add!, atomic_cas!
 using SharedArrays: SharedMatrix, SharedVector, sdata
-using ArnoldiMethod: LM, SR, LR, partialschur, partialeigen
+using ArnoldiMethod: partialschur, partialeigen
 using Random: AbstractRNG, shuffle
 import SparseArrays: sparse
 import Base: push!, popfirst!, isempty, getindex

--- a/src/centrality/eigenvector.jl
+++ b/src/centrality/eigenvector.jl
@@ -9,7 +9,7 @@ the \$i^{th}\$ element of \$\\mathbf{x}\$ in the equation
 ``
     \\mathbf{Ax} = λ \\mathbf{x}
 ``
-where \$\\mathbf{A}\$ is the adjacency matrix of the graph `g` 
+where \$\\mathbf{A}\$ is the adjacency matrix of the graph `g`
 with eigenvalue λ.
 
 By virtue of the Perron–Frobenius theorem, there is a unique and positive
@@ -25,5 +25,5 @@ eigenvector of the adjacency matrix \$\\mathbf{A}\$.
        Oxford University Press, USA, 2010, pp. 169.
 """
 function eigenvector_centrality(g::AbstractGraph)
-    return abs.(vec(eigs(adjacency_matrix(g); which=LM(), nev=1)[2]))::Vector{Float64}
+    return abs.(vec(eigs(adjacency_matrix(g); which=:LM, nev=1)[2]))::Vector{Float64}
 end

--- a/src/graphcut/normalized_cut.jl
+++ b/src/graphcut/normalized_cut.jl
@@ -132,11 +132,11 @@ function _recursive_normalized_cut(W, thres, num_cuts)
     end
 
     # get eigenvector corresponding to the second smallest generalized eigenvalue:
-    # v = eigs(D-W, D, nev=2, which=SR())[2][:,2]
+    # v = eigs(D-W, D, nev=2, which=:SR)[2][:,2]
     # At least some versions of ARPACK have a bug, this is a workaround
     invDroot = sqrt.(inv(D)) # equal to Cholesky factorization for diagonal D
     if n > 12
-        _, Q = eigs(invDroot' * (D - W) * invDroot; nev=12, which=SR())
+        _, Q = eigs(invDroot' * (D - W) * invDroot; nev=12, which=:SR)
         (size(Q, 2) <= 1) && return collect(1:m) # no 2nd eigenvector
         ret = convert(Vector, real(view(Q, :, 2)))
     else

--- a/src/linalg/LinAlg.jl
+++ b/src/linalg/LinAlg.jl
@@ -1,6 +1,6 @@
 module LinAlg
 
-using ArnoldiMethod: LM, SR, LR, partialschur, partialeigen
+using ArnoldiMethod: partialschur, partialeigen
 
 using SimpleTraits
 using SparseArrays: SparseMatrixCSC
@@ -50,7 +50,7 @@ export convert,
 function eigs(A; kwargs...)
     schr = partialschur(A; kwargs...)
     vals, vectors = partialeigen(schr[1])
-    reved = (kwargs[:which] == LR() || kwargs[:which] == LM())
+    reved = (kwargs[:which] == :LR || kwargs[:which] == :LM)
     k = min(get(kwargs, :nev, length(vals))::Int, length(vals))
     perm = sortperm(vals; by=real, rev=reved)[1:k]
     λ = vals[perm]

--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -185,12 +185,12 @@ function spectral_distance end
     A₂ = adjacency_matrix(G₂)
 
     λ₁ = if k < nv(G₁) - 1
-        eigs(A₁; nev=k, which=LR())[1]
+        eigs(A₁; nev=k, which=:LR)[1]
     else
         eigvals(Matrix(A₁))[end:-1:(end - (k - 1))]
     end
     λ₂ = if k < nv(G₂) - 1
-        eigs(A₂; nev=k, which=LR())[1]
+        eigs(A₂; nev=k, which=:LR)[1]
     else
         eigvals(Matrix(A₂))[end:-1:(end - (k - 1))]
     end

--- a/test/linalg/graphmatrices.jl
+++ b/test/linalg/graphmatrices.jl
@@ -1,5 +1,5 @@
 # export test_adjacency, test_laplacian, test_accessors, test_arithmetic, test_other
-using ArnoldiMethod: LM, SR, LR, partialschur, partialeigen
+using ArnoldiMethod: partialschur, partialeigen
 
 @testset "Graph matrices" begin
 
@@ -101,15 +101,15 @@ using ArnoldiMethod: LM, SR, LR, partialschur, partialeigen
         @test g(NormalizedLaplacian(adjhat)) > 1e-13
         @test g(StochasticLaplacian(stochmat)) > 1e-13
 
-        @test eigs(adjmat; which=LR())[1][1] > 1.0
-        @test eigs(stochmat; which=LR())[1][1] ≈ 1.0
-        @test eigs(avgmat; which=LR())[1][1] ≈ 1.0
-        @test eigs(lapl; which=LR())[1][1] > 2.0
-        @test eigs(sparse(lapl); which=SR())[1][2] > 0.0
-        @test eigs(sparse(lapl); which=SR())[1][1] < 1e-7
+        @test eigs(adjmat; which=:LR)[1][1] > 1.0
+        @test eigs(stochmat; which=:LR)[1][1] ≈ 1.0
+        @test eigs(avgmat; which=:LR)[1][1] ≈ 1.0
+        @test eigs(lapl; which=:LR)[1][1] > 2.0
+        @test eigs(sparse(lapl); which=:SR)[1][2] > 0.0
+        @test eigs(sparse(lapl); which=:SR)[1][1] < 1e-7
 
         lhat = NormalizedLaplacian(adjhat)
-        @test eigs(lhat; which=LR())[1][1] < 2.0 + 1e-9
+        @test eigs(lhat; which=:LR)[1][1] < 2.0 + 1e-9
     end
 
     function test_other(mat, n)
@@ -169,7 +169,7 @@ using ArnoldiMethod: LM, SR, LR, partialschur, partialeigen
         y = ahatp * perron(ahatp)
         @test dot(y, ahatp.perron) ≈ 0.0 atol = 1.0e-8
         @test sum(abs, y) ≈ 0.0 atol = 1.0e-8
-        eval, evecs = eigs(ahatp; which=LM())
+        eval, evecs = eigs(ahatp; which=:LM)
         @test eval[1] - (1 + 1.0e-8) <= 0
         @test dot(perron(ahatp), evecs[:, 1]) ≈ 0.0 atol = 1e-8
         ahat = ahatp.A
@@ -195,7 +195,7 @@ using ArnoldiMethod: LM, SR, LR, partialschur, partialeigen
 
     """Computes the stationary distribution of a random walk"""
     function stationarydistribution(R::StochasticAdjacency; kwargs...)
-        er = eigs(R; nev=1, which=LR(), kwargs...)
+        er = eigs(R; nev=1, which=:LR, kwargs...)
         l1 = er[1][1]
         abs(l1 - 1) < 1e-8 || error("failed to compute stationary distribution") # TODO 0.7: should we change the error type to InexactError?
         p = real(er[2][:, 1])

--- a/test/linalg/spectral.jl
+++ b/test/linalg/spectral.jl
@@ -1,6 +1,6 @@
 import Base: Matrix
 import Base: size
-using ArnoldiMethod: LM, SR, LR, partialschur, partialeigen
+using ArnoldiMethod: partialschur, partialeigen
 
 # using Graphs.LinAlg: eigs
 # just so that we can assert equality of matrices
@@ -152,7 +152,7 @@ Matrix(nbt::Nonbacktracking) = Matrix(sparse(nbt))
         B, emap = non_backtracking_matrix(g)
         Bs = sparse(nbt)
         @test sparse(B) == Bs
-        @test eigs(nbt; which=LR(), nev=1)[1] ≈ eigs(B; which=LR(), nev=1)[1] atol = 1e-5
+        @test eigs(nbt; which=:LR, nev=1)[1] ≈ eigs(B; which=:LR, nev=1)[1] atol = 1e-5
 
         # check that matvec works
         x = ones(Float64, nbt.m)


### PR DESCRIPTION
According to https://github.com/JuliaLinearAlgebra/ArnoldiMethod.jl/commit/56221508b32e2be8cc041733f32f1fd669ba1490
the authors of ArnoldiMethods.jl would prefer users to use the symbols `:LM`, `:SR`, `:LR`, `:SI`, `:LI`
instead of `LM()`, `SR()`, `LR()`, `SI()`, and `LI()` respectively.
Accordingly, I have made those adjustments and removed the unecessary now imports of `LM`, `SR`, `LR`, `SI` and `LI`.

