### PR TITLE
Faster dorogovtsev mendes

### DIFF
--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1494,24 +1494,29 @@ function dorogovtsev_mendes(
     n < 3 && throw(DomainError("n=$n must be at least 3"))
     rng = rng_from_rng_or_seed(rng, seed)
     g = cycle_graph(3)
+    bag_of_edges = Vector{SimpleEdge{Int}}(undef, 2*n - 3)
 
-    for iteration in 1:(n - 3)
-        chosenedge = rand(rng, 1:(2 * ne(g))) # undirected so each edge is listed twice in adjlist
-        u, v = -1, -1
-        for i in 1:nv(g)
-            edgelist = outneighbors(g, i)
-            if chosenedge > length(edgelist)
-                chosenedge -= length(edgelist)
-            else
-                u = i
-                v = edgelist[chosenedge]
-                break
-            end
-        end
+    bag_of_edges[1] = SimpleEdge(1, 2)
+    bag_of_edges[2] = SimpleEdge(1, 3)
+    bag_of_edges[3] = SimpleEdge(2, 3)
+    index = 3
+   
+    for _ in 1:n-3
+        # Choose random edge from bag
+        edge = bag_of_edges[rand(rng, 1:index)]
+        u, v = edge.src, edge.dst
 
-        add_vertex!(g)
-        add_edge!(g, nv(g), u)
-        add_edge!(g, nv(g), v)
+        # Add new vertex
+        add_vertex!(g) || throw(DomainError("Failed to add vertex. One possible explanation is that type $(eltype(g)) cannot represent enough vertices"))
+
+        # Add new edges
+        add_edge!(g, nv(g), u) || println("Failed to add edge $(nv(g)) -> $u")
+        add_edge!(g, nv(g), v) || println("Failed to add edge $(nv(g)) -> $v")
+
+        # Add new edges to bag
+        bag_of_edges[index] = SimpleEdge(nv(g), edge.src)
+        bag_of_edges[index + 1] = SimpleEdge(nv(g), edge.dst)
+    
     end
     return g
 end

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1494,20 +1494,24 @@ function dorogovtsev_mendes(
     n < 3 && throw(DomainError("n=$n must be at least 3"))
     rng = rng_from_rng_or_seed(rng, seed)
     g = cycle_graph(3)
-    bag_of_edges = Vector{SimpleEdge{Int}}(undef, 2*n - 3)
+    bag_of_edges = Vector{SimpleEdge{Int}}(undef, 2 * n - 3)
 
     bag_of_edges[1] = SimpleEdge(1, 2)
     bag_of_edges[2] = SimpleEdge(1, 3)
     bag_of_edges[3] = SimpleEdge(2, 3)
     index = 3
-   
-    for _ in 1:n-3
+
+    for _ in 1:(n - 3)
         # Choose random edge from bag
         edge = bag_of_edges[rand(rng, 1:index)]
         u, v = edge.src, edge.dst
 
         # Add new vertex
-        add_vertex!(g) || throw(DomainError("Failed to add vertex. One possible explanation is that type $(eltype(g)) cannot represent enough vertices"))
+        add_vertex!(g) || throw(
+            DomainError(
+                "Failed to add vertex. One possible explanation is that type $(eltype(g)) cannot represent enough vertices",
+            ),
+        )
 
         # Add new edges
         add_edge!(g, nv(g), u) || println("Failed to add edge $(nv(g)) -> $u")
@@ -1516,7 +1520,6 @@ function dorogovtsev_mendes(
         # Add new edges to bag
         bag_of_edges[index] = SimpleEdge(nv(g), edge.src)
         bag_of_edges[index + 1] = SimpleEdge(nv(g), edge.dst)
-    
     end
     return g
 end

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1507,11 +1507,7 @@ function dorogovtsev_mendes(
         u, v = src(edge), dst(edge)
 
         # Add new vertex
-        add_vertex!(g) || throw(
-            DomainError(
-                "Failed to add vertex. One possible explanation is that type $(eltype(g)) cannot represent enough vertices",
-            ),
-        )
+        add_vertex!(g)
         # Add new edges
         add_edge!(g, nv(g), u)
         add_edge!(g, nv(g), v)

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1494,7 +1494,7 @@ function dorogovtsev_mendes(
     n < 3 && throw(DomainError("n=$n must be at least 3"))
     rng = rng_from_rng_or_seed(rng, seed)
     g = cycle_graph(3)
-    bag_of_edges = Vector{SimpleEdge{Int}}(undef, 2 * n - 3)
+    bag_of_edges = Vector{SimpleEdge{Int}}(undef, 2 * n - 3) # Caching edges as they are added to avoid costly lookups
 
     bag_of_edges[1] = SimpleEdge(1, 2)
     bag_of_edges[2] = SimpleEdge(1, 3)
@@ -1512,14 +1512,14 @@ function dorogovtsev_mendes(
                 "Failed to add vertex. One possible explanation is that type $(eltype(g)) cannot represent enough vertices",
             ),
         )
-
         # Add new edges
-        add_edge!(g, nv(g), u) || println("Failed to add edge $(nv(g)) -> $u")
-        add_edge!(g, nv(g), v) || println("Failed to add edge $(nv(g)) -> $v")
+        add_edge!(g, nv(g), u)
+        add_edge!(g, nv(g), v)
 
         # Add new edges to bag
-        bag_of_edges[index] = SimpleEdge(nv(g), edge.src)
-        bag_of_edges[index + 1] = SimpleEdge(nv(g), edge.dst)
+        bag_of_edges[index + 1] = SimpleEdge(nv(g), edge.src)
+        bag_of_edges[index + 2] = SimpleEdge(nv(g), edge.dst)
+        index += 2
     end
     return g
 end

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1504,7 +1504,7 @@ function dorogovtsev_mendes(
     for _ in 1:(n - 3)
         # Choose random edge from bag
         edge = bag_of_edges[rand(rng, 1:index)]
-        u, v = edge.src, edge.dst
+        u, v = src(edge), dst(edge)
 
         # Add new vertex
         add_vertex!(g) || throw(

--- a/test/simplegraphs/generators/randgraphs.jl
+++ b/test/simplegraphs/generators/randgraphs.jl
@@ -382,6 +382,19 @@
         @test δ(g) == 2
         g = dorogovtsev_mendes(3; rng=rng)
         @test nv(g) == 3 && ne(g) == 3
+        @test δ(g) == 2 && Δ(g) == 2
+
+        # Testing that n=4 graph is one on the possible graphs
+        g = dorogovtsev_mendes(4; rng=rng)
+        @test has_edge(g, 1, 2) &&
+            has_edge(g, 1, 3) &&
+            has_edge(g, 2, 3) &&
+            (
+                has_edge(g, 1, 4) && has_edge(g, 2, 4) ||
+                has_edge(g, 2, 4) && has_edge(g, 3, 4) ||
+                has_edge(g, 1, 4) && has_edge(g, 3, 4)
+            )
+
         # testing domain errors
         @test_throws DomainError dorogovtsev_mendes(2, rng=rng)
         @test_throws DomainError dorogovtsev_mendes(-1, rng=rng)


### PR DESCRIPTION
Addresses #370.

This implementation has $O(N)$ runtime, while the previous implementation had $O(N^2)$ runtime. 

The optimization comes from storing all edges added at each iteration in an indexed table, allowing to draw a random edge in $O(1)$ time, while the previous implementation had to go through (on average) half on the nodes in order to draw a random edge, which takes $O(N)$ time. 

On my computer, this implementation uses approximately 16% more memory. 

It runs faster than the previous one even on small graphs ($N = 100$).