### PR TITLE
Avoid materializing intermediate adjacency list

### DIFF
--- a/src/SimpleGraphs/simpleedgeiter.jl
+++ b/src/SimpleGraphs/simpleedgeiter.jl
@@ -60,7 +60,6 @@ end
     eit::SimpleEdgeIter{G}, state=(one(eltype(eit.g)), 1)
 ) where {G <: AbstractSimpleGraph; IsDirected{G}}
     g = eit.g
-    fadjlist = fadj(g)
     T = eltype(g)
     n = T(nv(g))
     u, i = state
@@ -68,12 +67,12 @@ end
     n == 0 && return nothing
 
     @inbounds while true
-        list_u = fadjlist[u]
+        list_u = fadj(g, u)
         if i > length(list_u)
             u == n && return nothing
 
             u += one(u)
-            list_u = fadjlist[u]
+            list_u = fadj(g, u)
             i = 1
             continue
         end

--- a/src/SimpleGraphs/simpleedgeiter.jl
+++ b/src/SimpleGraphs/simpleedgeiter.jl
@@ -32,16 +32,15 @@ eltype(::Type{SimpleEdgeIter{SimpleDiGraph{T}}}) where {T} = SimpleDiGraphEdge{T
     eit::SimpleEdgeIter{G}, state=(one(eltype(eit.g)), 1)
 ) where {G <: AbstractSimpleGraph; !IsDirected{G}}
     g = eit.g
-    fadjlist = fadj(g)
     T = eltype(g)
     n = T(nv(g))
     u, i = state
 
     @inbounds while u < n
-        list_u = fadjlist[u]
+        list_u = fadj(g, u)
         if i > length(list_u)
             u += one(u)
-            i = searchsortedfirst(fadjlist[u], u)
+            i = searchsortedfirst(fadj(g, u), u)
             continue
         end
         e = SimpleEdge(u, list_u[i])

--- a/src/SimpleGraphs/simpleedgeiter.jl
+++ b/src/SimpleGraphs/simpleedgeiter.jl
@@ -48,7 +48,7 @@ eltype(::Type{SimpleEdgeIter{SimpleDiGraph{T}}}) where {T} = SimpleDiGraphEdge{T
         return e, state
     end
 
-    @inbounds (n == 0 || i > length(fadjlist[n])) && return nothing
+    @inbounds (n == 0 || i > length(fadj(g, n))) && return nothing
 
     e = SimpleEdge(n, n)
     state = (u, i + 1)


### PR DESCRIPTION
For graphs where the adjacency is not stored, this can lead to a lot of allocations when iterating over edges.

Before PR:
```julia
julia> g
{58089, 120148} directed simple Int32 graph

julia> typeof(g)
StaticGraphs.StaticDiGraph{Int32, Int32}

julia> @time collect(Graphs.edges(g));
 21.959129 seconds (330.20 k allocations: 260.015 GiB, 27.19% gc time, 0.21% compilation time)
```

After PR:
```julia
julia> @time collect(Graphs.edges(g));
  0.000396 seconds (3 allocations: 938.844 KiB)
```