### PR TITLE
Use main URL for Wikipedia, not mobile URL

### DIFF
--- a/src/Experimental/ShortestPaths/ShortestPaths.jl
+++ b/src/Experimental/ShortestPaths/ShortestPaths.jl
@@ -78,7 +78,7 @@ shortest paths.
 See `ShortestPathAlgorithm` for more details on the algorithm specifications.
 
 ### Implementation Notes
-The elements of `distmx` may be of any type that has a [Total Ordering](https://en.m.wikipedia.org/wiki/Total_order)
+The elements of `distmx` may be of any type that has a [Total Ordering](https://en.wikipedia.org/wiki/Total_order)
 and valid comparator, `zero` and `typemax` functions. Concretely, this means that
 distance matrices containing complex numbers are invalid.
 

--- a/src/Experimental/ShortestPaths/bfs.jl
+++ b/src/Experimental/ShortestPaths/bfs.jl
@@ -4,7 +4,7 @@ using Graphs.Experimental.Traversals
     struct BFS <: ShortestPathAlgorithm
 
 The structure used to configure and specify that [`shortest_paths`](@ref)
-should use the [Breadth-First Search algorithm](https://en.m.wikipedia.org/wiki/Breadth-first_search).
+should use the [Breadth-First Search algorithm](https://en.wikipedia.org/wiki/Breadth-first_search).
 
 An optional sorting algorithm may be specified (default = no sorting).
 Sorting helps maintain cache locality and will improve performance on

--- a/src/biconnectivity/bridge.jl
+++ b/src/biconnectivity/bridge.jl
@@ -1,7 +1,7 @@
 """
     bridges(g)
 
-Compute the [bridges](https://en.m.wikipedia.org/wiki/Bridge_(graph_theory))
+Compute the [bridges](https://en.wikipedia.org/wiki/Bridge_(graph_theory))
 of a connected graph `g` and return an array containing all bridges, i.e edges
 whose deletion increases the number of connected components of the graph.
 # Examples


### PR DESCRIPTION
I noticed these links to the mobile Wikipedia site, figured it would be better to be consistent across the docs.