### PR TITLE
Replaced Vector data structure by BitSet in greedy_color

### DIFF
--- a/src/traversals/greedy_color.jl
+++ b/src/traversals/greedy_color.jl
@@ -23,16 +23,18 @@ function perm_greedy_color(g::AbstractGraph, seq::Vector{T}) where {T<:Integer}
 
     has_self_loops(g) && throw(ArgumentError("graph must not have self loops"))
 
+    colors_used = BitSet()
+
     for v in seq
-        colors_used = zeros(Bool, nvg)
+        empty!(colors_used)
         for w in neighbors(g, v)
             if seen[w]
-                colors_used[cols[w]] = true
+                push!(colors_used, cols[w])
             end
         end
 
         for i in one(T):nvg
-            if colors_used[i] == false
+            if i ∉ colors_used
                 cols[v] = i
                 break
             end

--- a/src/traversals/greedy_color.jl
+++ b/src/traversals/greedy_color.jl
@@ -23,7 +23,7 @@ function perm_greedy_color(g::AbstractGraph, seq::Vector{T}) where {T<:Integer}
 
     has_self_loops(g) && throw(ArgumentError("graph must not have self loops"))
 
-    colors_used = BitSet()
+    colors_used = Set{T}()
 
     for v in seq
         empty!(colors_used)

--- a/src/traversals/greedy_color.jl
+++ b/src/traversals/greedy_color.jl
@@ -23,7 +23,7 @@ function perm_greedy_color(g::AbstractGraph, seq::Vector{T}) where {T<:Integer}
 
     has_self_loops(g) && throw(ArgumentError("graph must not have self loops"))
 
-    colors_used = Set{T}()
+    colors_used = BitSet()
 
     for v in seq
         empty!(colors_used)


### PR DESCRIPTION
This PR adresses #378 .

Replacing Vector with a Set yields immediate speedup of 50-100x on my machine. 

As the we are using dense sets of integers from 1 to the number of colors to color the graph (i.e relatively small integers), BitSet implementation seems to be the most appropriate here. (and is also faster on my machine, even though I have not tested on an extensive benchmark suite)

Im open to feedback of course (I am still pretty new here) :))