### PR TITLE
Speed up `has_path` by avoiding `popfirst!` and `push!`

### DIFF
--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -182,15 +182,18 @@ function has_path(
     end
     (seen[u] || seen[v]) && return false
     u == v && return true # cannot be separated
-    next = Vector{T}()
-    push!(next, u)
+    next = Vector{T}(undef, nv(g))
+    front = back = 1
+    next[front] = u
     seen[u] = true
-    while !isempty(next)
-        src = popfirst!(next) # get new element from queue
+    while front <= back
+        src = next[front]
+        front += 1 # dequeue; pop from queue
         for vertex in outneighbors(g, src)
             vertex == v && return true
             if !seen[vertex]
-                push!(next, vertex) # push onto queue
+                back += 1
+                next[back] = vertex # enqueue; push onto queue
                 seen[vertex] = true
             end
         end


### PR DESCRIPTION
This speeds up `has_path` considerably by allocating the `next` buffer up front, avoiding the need to `push!` and `popfirst!` (and hence resize / reallocate) during the search.

Examples below (`has_path` = old implementation; `new_has_path` = implementation in this PR):

```jl
julia> using Graphs, Chairmarks

julia> g = path_graph(4)
julia> @b has_path($g, 1, 3) # true
96.970 ns (4 allocs: 272 bytes)
julia> @b new_has_path($g, 1, 3) # true
68.720 ns (3 allocs: 224 bytes)

julia> g = path_graph(10)
julia> @b has_path($g, 1, 10) # true
162.154 ns (4 allocs: 272 bytes)
julia> @b new_has_path($g, 1, 10) # true
94.956 ns (3 allocs: 272 bytes)

julia> p = complete_multipartite_graph(Int8[5,5,5])
julia> @b has_path($p, 1, 15) # true
139.452 ns (5 allocs: 288 bytes)
julia> @b new_has_path($p, 1, 15) # true
72.054 ns (3 allocs: 192 bytes)

julia> pp = SimpleGraph(30, vcat([p.fadjlist, [v .+ Int8(15) for v in p.fadjlist]]...))
julia> @b has_path($pp, 1, 16) # false
322.962 ns (5 allocs: 304 bytes)
julia> @b new_has_path($pp, 1, 16) # false
183.883 ns (3 allocs: 224 bytes)
```

It can occasionally be slower if the graph is very large and the vertices are very "close", e.g.:
```jl
julia> g = path_graph(1000)

julia> @b has_path($g, 1, 1000)
11.267 μs (4 allocs: 1.266 KiB)
julia> @b new_has_path($g, 1, 1000)
5.283 μs (3 allocs: 9.062 KiB)

julia> @b has_path($g, 1, 3)
148.652 ns (4 allocs: 1.266 KiB)
julia> @b new_has_path($g, 1, 3)
251.704 ns (3 allocs: 9.062 KiB)
```
For the above example, the new implementation is faster for all vertices separated by more than 14 steps. 

Overall, I think this should be a very worthwhile trade-off for most applications.