### PR TITLE
minor addition to `edges` docstring

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -183,7 +183,7 @@ vertices(g::AbstractGraph) = _NI("vertices")
     edges(g)
 
 Return (an iterator to or collection of) the edges of a graph.
-For `AbstractSimpleGraph`s it returns a `SimpleEdgeIter`.
+For `AbstractSimpleGraph`s it returns a `SimpleEdgeIter` (lexicographical order).
 The expressions `e in edges(g)` and `e ∈ edges(g)` evaluate as
 calls to [`has_edge`](@ref).
 


### PR DESCRIPTION
Seeing that `edges` is lexicographical took me a minute longer than necessary, so I thought this small addition is warranted.