### PR TITLE
add non-allocating enumerate_paths!

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -253,6 +253,7 @@ export
     has_negative_edge_cycle_spfa,
     has_negative_edge_cycle,
     enumerate_paths,
+    enumerate_paths!,
     johnson_shortest_paths,
     floyd_warshall_shortest_paths,
     transitiveclosure!,

--- a/test/shortestpaths/bellman-ford.jl
+++ b/test/shortestpaths/bellman-ford.jl
@@ -62,6 +62,8 @@
         @test getfield.(y.dists, :val) == getfield.(z.dists, :val) == [Inf, 0, 6, 17, 33]
         @test @inferred(enumerate_paths(z))[2] == []
         @test @inferred(enumerate_paths(z))[4] == enumerate_paths(z, 4) == [2, 3, 4]
+        @test @inferred(enumerate_paths!([[0]], z, 4:4))[1] == [2, 3, 4]
+        @test_throws ArgumentError enumerate_paths!([[0, 0], [0, 0]], z, 4:4)
         @test @inferred(!has_negative_edge_cycle(g))
         @test @inferred(!has_negative_edge_cycle(g, d3))
 


### PR DESCRIPTION
This PR adds an in-place version of `enumerate_paths` - `enumerate_paths!`, that `enumerate_paths` now calls itself after making the required allocations.

This can greatly improve performance where you need to call it many times. I also removed allocations in `enumerate_paths` functions, such as allocations of `Vector{Int}` where `UnitRange` works fine in its place.

(This may need a specific test, although it will run in the current tests anyway - I can write that if its considered to be merged)