### PR TITLE
Make Julia v1.10 (LTS) min version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.6'
+          - '1.10'
           - 'pre'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "1.12.0"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Inflate = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
@@ -18,7 +17,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 Aqua = "0.6"
 ArnoldiMethod = "0.4"
-Compat = "3.40, 4"
 DataStructures = "0.17, 0.18"
 Documenter = "0.27"
 Inflate = "0.1.3"
@@ -26,7 +24,7 @@ JuliaFormatter = "1"
 SimpleTraits = "0.9"
 StableRNGs = "1"
 Statistics = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/Experimental/ShortestPaths/johnson.jl
+++ b/src/Experimental/ShortestPaths/johnson.jl
@@ -1,7 +1,5 @@
 
 # Currently used to support the ismutable function that is not available in Julia < v1.7
-using Compat
-
 """
     struct Johnson <: ShortestPathAlgorithm
 
@@ -34,7 +32,7 @@ function shortest_paths(
         shortest_paths(g, vertices(g), distmx, BellmanFord())
     )
 
-    @compat if !ismutable(distmx) && type_distmx != Graphs.DefaultDistance
+    if !ismutable(distmx) && type_distmx != Graphs.DefaultDistance
         distmx = sparse(distmx) # Change reference, not value
     end
 
@@ -58,7 +56,7 @@ function shortest_paths(
         dists[:, v] .+= wt_transform[v] # Vertical traversal preferred
     end
 
-    @compat if ismutable(distmx)
+    if ismutable(distmx)
         for e in edges(g)
             distmx[src(e), dst(e)] += wt_transform[dst(e)] - wt_transform[src(e)]
         end

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -6,9 +6,6 @@ using SimpleTraits
 using ArnoldiMethod: LM, SR, LR, partialschur, partialeigen
 using Statistics: mean
 
-# Currently used to support the ismutable function that is not available in Julia < v1.7
-using Compat
-
 using Inflate: InflateGzipStream
 using DataStructures:
     IntDisjointSets,

--- a/src/Parallel/shortestpaths/johnson.jl
+++ b/src/Parallel/shortestpaths/johnson.jl
@@ -1,7 +1,4 @@
 
-# Currently used to support the ismutable function that is not available in Julia < v1.7
-using Compat
-
 function johnson_shortest_paths(
     g::AbstractGraph{U}, distmx::AbstractMatrix{T}=weights(g)
 ) where {T<:Real} where {U<:Integer}
@@ -10,7 +7,7 @@ function johnson_shortest_paths(
     # Change when parallel implementation of Bellman Ford available
     wt_transform = bellman_ford_shortest_paths(g, vertices(g), distmx).dists
 
-    @compat if !ismutable(distmx) && type_distmx != Graphs.DefaultDistance
+    if !ismutable(distmx) && type_distmx != Graphs.DefaultDistance
         distmx = sparse(distmx) # Change reference, not value
     end
 
@@ -30,7 +27,7 @@ function johnson_shortest_paths(
         dists[:, v] .+= wt_transform[v] # Vertical traversal preferred
     end
 
-    @compat if ismutable(distmx)
+    if ismutable(distmx)
         for e in edges(g)
             distmx[src(e), dst(e)] += wt_transform[dst(e)] - wt_transform[src(e)]
         end

--- a/src/core.jl
+++ b/src/core.jl
@@ -401,14 +401,8 @@ can accommodate all vertices.
 May also return the original graph if the eltype does not change.
 """
 function squash(g::AbstractGraph)
-
-    # TODO this version check can be removed when we increase the required Julia version
     deprecation_msg = "squash(::AbstractGraph) is deprecated in favor of methods that specialize on the graph type."
-    if VERSION >= v"1.5.2"
-        Base.depwarn(deprecation_msg, :squash; force=true)
-    else
-        Base.depwarn(deprecation_msg, :squash)
-    end
+    Base.depwarn(deprecation_msg, :squash; force=true)
 
     gtype = is_directed(g) ? DiGraph : Graph
     validtypes = [UInt8, UInt16, UInt32, UInt64, Int64]

--- a/src/shortestpaths/johnson.jl
+++ b/src/shortestpaths/johnson.jl
@@ -36,7 +36,7 @@ function johnson_shortest_paths(
     wt_transform =
         bellman_ford_shortest_paths(g, collect_if_not_vector(vertices(g)), distmx).dists
 
-    @compat if !ismutable(distmx) && type_distmx != Graphs.DefaultDistance
+    if !ismutable(distmx) && type_distmx != Graphs.DefaultDistance
         distmx = sparse(distmx) # Change reference, not value
     end
 
@@ -60,7 +60,7 @@ function johnson_shortest_paths(
         dists[:, v] .+= wt_transform[v] # Vertical traversal preferred
     end
 
-    @compat if ismutable(distmx)
+    if ismutable(distmx)
         for e in edges(g)
             distmx[src(e), dst(e)] += wt_transform[dst(e)] - wt_transform[src(e)]
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,6 @@ using Graphs.Test
 using Test
 using SparseArrays
 using LinearAlgebra
-using Compat
 using DelimitedFiles
 using Base64
 using Random
@@ -151,15 +150,13 @@ tests = [
 
 @testset verbose = true "Graphs" begin
     @testset "Code quality (JET.jl)" begin
-        if VERSION >= v"1.9"
-            @assert get_pkg_version("JET") >= v"0.8.4"
-            JET.test_package(
-                Graphs;
-                target_defined_modules=true,
-                ignore_missing_comparison=true,
-                mode=:typo,  # TODO: switch back to `:basic` once the union split caused by traits is fixed
-            )
-        end
+        @assert get_pkg_version("JET") >= v"0.8.4"
+        JET.test_package(
+            Graphs;
+            target_defined_modules=true,
+            ignore_missing_comparison=true,
+            mode=:typo,  # TODO: switch back to `:basic` once the union split caused by traits is fixed
+        )
     end
 
     @testset "Code quality (Aqua.jl)" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -38,7 +38,7 @@
         @test Graphs.rng_from_rng_or_seed(nothing, nothing) === Random.GLOBAL_RNG
         @test Graphs.rng_from_rng_or_seed(nothing, -10) === Random.GLOBAL_RNG
         @test Graphs.rng_from_rng_or_seed(nothing, 456) == Graphs.getRNG(456)
-        @compat if ismutable(Random.GLOBAL_RNG)
+        if ismutable(Random.GLOBAL_RNG)
             @test Graphs.rng_from_rng_or_seed(nothing, 456) !== Random.GLOBAL_RNG
         end
         rng = Random.MersenneTwister(789)


### PR DESCRIPTION
This PR makes Julia `v1.10` - the latest long-term support version the minimum version of this package.

Additionally
- Remove some code that was only necessary for older versions
- Remove `Compat.jl` dependency as it is not needed anymore (we can always add it back)

I noticed there are some TODO comments for changing the error types in some cases when we upgrade Julia - I left them in for now as this might be a slightly breaking case.
