### PR TITLE
autoformat bot in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,5 @@ Please make sure to leave this PR editable by maintainers of this repo.
 Please make sure you have consulted [CONTRIBUTING](https://github.com/JuliaGraphs/Graphs.jl/blob/master/CONTRIBUTING.md)
 
 The linter bot might add new commits to your PR (e.g. to take care of formatting issues). Feel free to overwrite these commits. 
+
+If the linter bot is the last one to put in a commit, **THE TESTS WILL NOT RUN**. Either lint/format your contributions yourself as described in CONTRIBUTING.md or close&reopen the PR to reset the test runner.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Please make sure to leave this PR editable by maintainers of this repo.
+
+Please make sure you have consulted [CONTRIBUTING](https://github.com/JuliaGraphs/Graphs.jl/blob/master/CONTRIBUTING.md)
+
+The linter bot might add new commits to your PR (e.g. to take care of formatting issues). Feel free to overwrite these commits. 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 env:
   JULIA_NUM_THREADS: 2
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main') || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 on:
   pull_request:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/prprecommit.yml
+++ b/.github/workflows/prprecommit.yml
@@ -1,0 +1,32 @@
+name: PR Pre-Commit Bot
+env:
+  JULIA_NUM_THREADS: 2
+on:
+  pull_request:
+    branches: ["master", "main"]
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+    - name: Setup Julia
+      uses: julia-actions/setup-julia@v2
+      with:
+        version: '1'
+    - name: Setup JuliaFormatter
+      run: |
+        julia -e '
+          using Pkg
+          Pkg.add(name="JuliaFormatter", version="1.0.62")'
+    - name: Setup Python
+      uses: actions/setup-python@v3
+    - name: Run pre-commit
+      uses: pre-commit/action@v3.0.1
+      continue-on-error: true
+    - name: Potentially commit changes
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: linter bot commit -- feel free to overwrite

--- a/.github/workflows/prprecommit.yml
+++ b/.github/workflows/prprecommit.yml
@@ -1,6 +1,12 @@
 name: PR Pre-Commit Bot
 env:
   JULIA_NUM_THREADS: 2
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main') || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 on:
   pull_request:
     branches: ["master", "main"]

--- a/.github/workflows/prprecommit.yml
+++ b/.github/workflows/prprecommit.yml
@@ -22,6 +22,7 @@ jobs:
       uses: julia-actions/setup-julia@v2
       with:
         version: '1'
+    - uses: julia-actions/cache@v2
     - name: Setup JuliaFormatter
       run: |
         julia -e '

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: "https://github.com/domluna/JuliaFormatter.jl"
+  rev: "v1.0.62"
+  hooks:
+  - id: "julia-formatter"

--- a/src/core.jl
+++ b/src/core.jl
@@ -23,7 +23,7 @@ julia> is_ordered(first(edges(g)))
 false
 ```
 """
-is_ordered(e::AbstractEdge) = src(e) <= dst(e)
+is_ordered(e::AbstractEdge )   = src(e) <= dst(e)
 
 """
     add_vertices!(g, n)
@@ -48,7 +48,7 @@ add_vertices!(g::AbstractGraph, n::Integer) = sum([add_vertex!(g) for i in 1:n])
     indegree(g[, v])
 
 Return a vector containing the indegrees of every vertex of the graph `g`, where
-the indegree of a vertex is defined as the number of edges which end at that 
+the indegree of a vertex is defined as the number of edges which end at that
 vertex. If `v` is specified and is a single vertex, only return the indegree of
 `v`. If `v` is specified and is a vector of vertices, only return the indegrees
 of the vertices in `v`.
@@ -85,7 +85,7 @@ indegree(g::AbstractGraph, vs=vertices(g)) = [indegree(g, x) for x in vs]
     outdegree(g[, v])
 
 Return a vector containing the outdegrees of every vertex of the graph `g`, where
-the outdegree of a vertex is defined as the number of edges which start at that 
+the outdegree of a vertex is defined as the number of edges which start at that
 vertex. If `v` is specified and is a single vertex, only return the outdegree of
 `v`. If `v` is specified and is a vector of vertices, only return the outdegrees
 of the vertices in `v`.
@@ -124,7 +124,7 @@ outdegree(g::AbstractGraph, vs=vertices(g)) = [outdegree(g, x) for x in vs]
 Return a vector containing the degrees of every vertex of the graph `g`, where
 the degree of a vertex is defined as the number of edges which start or end at
 that vertex. For directed graphs, the degree of a vertex is equal to the sum of
-its indegree and outdegree. If `v` is specified and is a single vertex, only 
+its indegree and outdegree. If `v` is specified and is a single vertex, only
 return the degree of `v`. If `v` is specified and is a vector of vertices, only
 return the degrees of the vertices in `v`.
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -23,7 +23,7 @@ julia> is_ordered(first(edges(g)))
 false
 ```
 """
-is_ordered(e::AbstractEdge )   = src(e) <= dst(e)
+is_ordered(e::AbstractEdge) = src(e) <= dst(e)
 
 """
     add_vertices!(g, n)


### PR DESCRIPTION
Each commit is reasonably selfcontained:

- add an autoformat bot that will create a commit in this same PR with formatting fixes
- if a PR is pushed to, stop the CI running on old commits, to avoid burning our free credits
- use a more recent simpler version of the cache action
- add a misformat error on purpose to test the bot
- add a PR template explaining the presence of the bot
- the automated linter commit that was generated by the bot, fixing my on-purpose injected mistake

@rafaqz @simonschoelly , let me know if this fits your needs, I would like to merge it soon so we can remove one of the burdens putting off new contributors.