### PR TITLE
turn off the precommit CI action

### DIFF
--- a/.github/workflows/prprecommit.yml
+++ b/.github/workflows/prprecommit.yml
@@ -7,9 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main') || github.run_number }}
   # Cancel intermediate builds, but only if it is a pull request build.
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-on:
-  pull_request:
-    branches: ["master", "main"]
+#on:
+#  pull_request:
+#    branches: ["master", "main"]
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Temporarily undo most of #437, to complete the erroneously skipped review and to fix the fact that the CI does not run when the PR is coming from a fork.

The concurrency fixes to the existing actions is kept in as well as the general-purpose precommit configuration.