### PR TITLE
Add LEMON graph structures and tests

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -557,6 +557,8 @@ include("vertexcover/random_vertex_cover.jl")
 include("Experimental/Experimental.jl")
 include("Parallel/Parallel.jl")
 include("Test/Test.jl")
+include("LEMON/LEMON.jl")
 
 using .LinAlg
+using .LEMON
 end # module

--- a/src/LEMON/LEMON.jl
+++ b/src/LEMON/LEMON.jl
@@ -1,0 +1,45 @@
+module LEMON
+
+using Graphs
+
+export LEMONGraph, LEMONDiGraph
+
+abstract type AbstractLEMONGraph <: AbstractGraph{Int} end
+
+struct LEMONGraph <: AbstractLEMONGraph
+    n::Int
+    m::Int
+
+    function LEMONGraph(n::Integer=0)
+        n >= 0 || throw(DomainError(n, "Number of vertices must be non-negative"))
+        return new(n, 0)
+    end
+end
+
+struct LEMONDiGraph <: AbstractLEMONGraph
+    n::Int
+    m::Int
+
+    function LEMONDiGraph(n::Integer=0)
+        n >= 0 || throw(DomainError(n, "Number of vertices must be non-negative"))
+        return new(n, 0)
+    end
+end
+
+Graphs.is_directed(::Type{LEMONGraph}) = false
+Graphs.is_directed(::Type{LEMONDiGraph}) = true
+
+Graphs.nv(g::AbstractLEMONGraph) = g.n
+Graphs.ne(g::AbstractLEMONGraph) = g.m
+
+Graphs.vertices(g::AbstractLEMONGraph) = 1:nv(g)
+
+function Base.show(io::IO, g::LEMONGraph)
+    return print(io, "{$(nv(g)), $(ne(g))} undirected LEMON graph")
+end
+
+function Base.show(io::IO, g::LEMONDiGraph)
+    return print(io, "{$(nv(g)), $(ne(g))} directed LEMON graph")
+end
+
+end

--- a/test/LEMON/lemon.jl
+++ b/test/LEMON/lemon.jl
@@ -1,0 +1,39 @@
+using Graphs.LEMON
+
+@testset "LEMON" begin
+    @testset "Graph Construction" begin
+        g = LEMONGraph()
+        @test nv(g) == 0
+        @test ne(g) == 0
+        @test !is_directed(g)
+        
+        g2 = LEMONGraph(5)
+        @test nv(g2) == 5
+        @test ne(g2) == 0
+        
+        @test_throws DomainError LEMONGraph(-1)
+    end
+    
+    @testset "DiGraph Construction" begin
+        g = LEMONDiGraph()
+        @test nv(g) == 0
+        @test ne(g) == 0
+        @test is_directed(g)
+        
+        g2 = LEMONDiGraph(5)
+        @test nv(g2) == 5
+        @test ne(g2) == 0
+        
+        @test_throws DomainError LEMONDiGraph(-1)
+    end
+    
+    @testset "Basic Properties" begin
+        g = LEMONGraph(10)
+        @test vertices(g) == 1:10
+        @test eltype(g) == Int
+        
+        dg = LEMONDiGraph(10)
+        @test vertices(dg) == 1:10
+        @test eltype(dg) == Int
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,6 +148,7 @@ tests = [
     "vertexcover/random_vertex_cover",
     "trees/prufer",
     "experimental/experimental",
+    "LEMON/lemon",
 ]
 
 @testset verbose = true "Graphs" begin


### PR DESCRIPTION
## Summary

This PR introduces the foundational structure for the LEMON wrapper module in Graphs.jl, addressing issue #447. This is the first of several small PRs that will incrementally build the complete LEMON wrapper functionality.

## What's included

- Created `src/LEMON/LEMON.jl` module with basic graph types:
  - `AbstractLEMONGraph` abstract type
  - `LEMONGraph` for undirected graphs
  - `LEMONDiGraph` for directed graphs
- Implemented minimal required interface methods:
  - `nv()` - number of vertices
  - `ne()` - number of edges  
  - `vertices()` - vertex iterator
  - `is_directed()` - graph directionality check
  - `show()` - display methods
- Added basic test suite in `test/LEMON/lemon.jl`
- Integrated LEMON module into main Graphs.jl exports

## Testing

All tests pass:
```julia
julia> include("test/LEMON/lemon.jl")
Test Summary: | Pass  Total  Time
LEMON         |   16     16  0.1s
```

## Example usage

```julia
using Graphs, Graphs.LEMON

# Create undirected LEMON graph with 5 vertices
g = LEMONGraph(5)
# Output: {5, 0} undirected LEMON graph

# Create directed LEMON graph
dg = LEMONDiGraph(10)
# Output: {10, 0} directed LEMON graph

nv(g)  # 5
ne(g)  # 0
is_directed(g)  # false
is_directed(dg) # true
```
<img width="1504" height="210" alt="image" src="https://github.com/user-attachments/assets/83b5748f-8a67-4813-8f63-052cf809ed55" />

## Next steps

Future PRs will add:
1. Graph conversion utilities between SimpleGraph and LEMON formats
2. Complete Graph API implementation (add_vertex!, add_edge!, etc.)
3. Algorithm dispatch to LEMON implementations
4. GraphsInterfaceChecker.jl integration

## Related to

- Issue #447: A reliable idiomatic wrapper for the C++ library `LEMON` 
- This work is funded by the National Science Foundation and NSF Center for Quantum Networks


## Checklist

- [x] Tests pass locally
- [x] Code follows Julia formatting conventions
- [x] Module is properly exported
- [x] Basic documentation included
