### PR TITLE
fix CI: avoid JET.jl `UndefVarError` warnings

### DIFF
--- a/src/centrality/betweenness.jl
+++ b/src/centrality/betweenness.jl
@@ -141,22 +141,15 @@ end
 function _rescale!(
     betweenness::Vector{Float64}, n::Integer, normalize::Bool, directed::Bool, k::Integer
 )
+    scale = nothing
     if normalize
-        if n <= 2
-            do_scale = false
-        else
-            do_scale = true
+        if 2 < n
             scale = 1.0 / ((n - 1) * (n - 2))
         end
-    else
-        if !directed
-            do_scale = true
-            scale = 1.0 / 2.0
-        else
-            do_scale = false
-        end
+    elseif !directed
+        scale = 1.0 / 2.0
     end
-    if do_scale
+    if !isnothing(scale)
         if k > 0
             scale = scale * n / k
         end

--- a/src/persistence/lg.jl
+++ b/src/persistence/lg.jl
@@ -58,23 +58,23 @@ function _lg_skip_one_graph(f::IO, n_e::Integer)
 end
 
 function _parse_header(s::AbstractString)
-    addl_info = false
     nvstr, nestr, dirundir, graphname = split(s, r"s*,s*"; limit=4)
+    addl = nothing
     if occursin(",", graphname) # version number and type
         graphname, _ver, _dtype, graphcode = split(graphname, r"s*,s*")
         ver = parse(Int, _ver)
         dtype = getfield(Main, Symbol(_dtype))
-        addl_info = true
+        addl = (ver, dtype, graphcode)
     end
     n_v = parse(Int, nvstr)
     n_e = parse(Int, nestr)
     dirundir = strip(dirundir)
     directed = !(dirundir == "u")
     graphname = strip(graphname)
-    if !addl_info
+    if addl === nothing
         header = LGHeader(n_v, n_e, directed, graphname)
     else
-        header = LGHeader(n_v, n_e, directed, graphname, ver, dtype, graphcode)
+        header = LGHeader(n_v, n_e, directed, graphname, addl...)
     end
     return header
 end


### PR DESCRIPTION
Rely on union-splitting instead.