### PR TITLE
Fix warning from DataStructures.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ GraphsSharedArraysExt = "SharedArrays"
 [compat]
 ArnoldiMethod = "0.4"
 Distributed = "1"
-DataStructures = "0.18, 0.19"
+DataStructures = "0.19"
 Inflate = "0.1.3"
 LinearAlgebra = "1"
 Random = "1"

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -8,7 +8,7 @@ using Statistics: mean
 
 using Inflate: InflateGzipStream
 using DataStructures:
-    IntDisjointSets,
+    IntDisjointSet,
     PriorityQueue,
     dequeue!,
     dequeue_pair!,

--- a/src/graphcut/karger_min_cut.jl
+++ b/src/graphcut/karger_min_cut.jl
@@ -23,7 +23,7 @@ function karger_min_cut(g::AbstractGraph{T}) where {T<:Integer}
     nvg < 2 && return zeros(Int, nvg)
     nvg == 2 && return [1, 2]
 
-    connected_vs = IntDisjointSets(nvg)
+    connected_vs = IntDisjointSet(nvg)
     num_components = nvg
 
     for e in shuffle(collect(edges(g)))

--- a/src/spanningtrees/boruvka.jl
+++ b/src/spanningtrees/boruvka.jl
@@ -15,7 +15,7 @@ function boruvka_mst end
 @traitfn function boruvka_mst(
     g::AG::(!IsDirected), distmx::AbstractMatrix{T}=weights(g); minimize=true
 ) where {T<:Number,U,AG<:AbstractGraph{U}}
-    djset = IntDisjointSets(nv(g))
+    djset = IntDisjointSet(nv(g))
     # maximizing Z is the same as minimizing -Z
     # mode will indicate the need for the -1 multiplication
     mode = minimize ? 1 : -1

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -12,7 +12,7 @@ function kruskal_mst end
 @traitfn function kruskal_mst(
     g::AG::(!IsDirected), distmx::AbstractMatrix{T}=weights(g); minimize=true
 ) where {T<:Number,U,AG<:AbstractGraph{U}}
-    connected_vs = IntDisjointSets(nv(g))
+    connected_vs = IntDisjointSet(nv(g))
 
     mst = Vector{edgetype(g)}()
     nv(g) <= 1 && return mst

--- a/src/traversals/maxadjvisit.jl
+++ b/src/traversals/maxadjvisit.jl
@@ -30,7 +30,7 @@ assumed to be 1.
     # still appearing in fadjlist. When iterating neighbors, is_merged makes sure we
     # don't consider them
     is_merged = falses(nvg)
-    merged_vertices = IntDisjointSets(U(nvg))
+    merged_vertices = IntDisjointSet(U(nvg))
     graph_size = nvg
     # We need to mutate the weight matrix,
     # and we need it clean (0 for non edges)


### PR DESCRIPTION
This is a really basic warning, but I think it didn't get fixed because the tests are annoyingly using JuliaFormatter which is not compatible with the latest version of DataStructures.jl?

Could someone please jump in and fix the tests?