### PR TITLE
start a git blame ignore revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# updating to Formatter v2
+f4b70cd8bbbcd43bf127bbe2acf3f7a11aef7942


### PR DESCRIPTION
Same style as what you see in the julia repo https://github.com/JuliaLang/julia/blob/master/.git-blame-ignore-revs

It enables much easier use of git blame for investigating past changes to the code base. I find this to be extremely important for very large projects like Graphs.jl that at the same time suffer from having very few maintainers (especially maintainers like me that were not part of the initial development of the package)