### PR TITLE
Optimization: iFUB algorithm for unweighted graph diameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Graphs"
 uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-version = "1.13.2"
+version = "1.13.3"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"

--- a/src/distance.jl
+++ b/src/distance.jl
@@ -95,7 +95,7 @@ end
 Given a graph and optional distance matrix, or a vector of precomputed
 eccentricities, return the maximum eccentricity of the graph.
 
-An optimizied BFS algorithm (iFUB) is for unweighted graphs, both in [undirected](https://www.sciencedirect.com/science/article/pii/S0304397512008687) 
+An optimizied BFS algorithm (iFUB) is used for unweighted graphs, both in [undirected](https://www.sciencedirect.com/science/article/pii/S0304397512008687) 
 and [directed](https://link.springer.com/chapter/10.1007/978-3-642-30850-5_10) cases.
 
 # Examples
@@ -109,6 +109,8 @@ julia> diameter(path_graph(5))
 4
 ```
 """
+function diameter end
+
 diameter(eccentricities::Vector) = maximum(eccentricities)
 
 diameter(g::AbstractGraph) = diameter(g, weights(g))

--- a/test/distance.jl
+++ b/test/distance.jl
@@ -81,7 +81,6 @@
 
         NUM_SAMPLES = 50 # Adjust this to change test duration
 
-        Random.seed!(42)
         for i in 1:NUM_SAMPLES
             # Random unweighted Graphs
             n = rand(10:1000) # Small to Medium size graphs


### PR DESCRIPTION
Implement iFUB algorithm for diameter calculation of unweighted graphs, `SimpleGraph` and `SimpleDiGraph`

Below is a comparison with the original diameter calculation logic, ran on my desktop.

```
using Graphs

g = erdos_renyi(10000, 0.005) # 10k nodes, sparse

# New implentation
@time d = diameter(g) # 0.910222 seconds (372.05 k allocations: 6.602 MiB)

# Original Method
original_diameter(g) = maximum(eccentricity(g)) 
@time original_diameter(g) # 41.471079 seconds (650.01 k allocations: 13.515 GiB, 3.59% gc time)
```