### PR TITLE
feat : Add VNGraphs.jl stubs for chromatic_number and edge_chromatic_number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ We follow SemVer as most of the Julia ecosystem. Below you might see the "breaki
 
 ## unreleased
 - `is_articulation(g, v)` for checking whether a single vertex is an articulation point
+- `chromatic_number` and `edge_chromatic_number` stubs (implemented in `VNGraphs.jl`)
 
 
 ## v1.14.0 - 2026-02-26

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -60,6 +60,7 @@ pages_files = [
     "Algorithms API" => [
         "algorithms/biconnectivity.md",
         "algorithms/centrality.md",
+        "algorithms/coloring.md",
         "algorithms/community.md",
         "algorithms/connectivity.md",
         "algorithms/cut.md",

--- a/docs/src/algorithms/coloring.md
+++ b/docs/src/algorithms/coloring.md
@@ -1,0 +1,18 @@
+# Graph Coloring
+
+_Graphs.jl_ provides stubs for graph coloring algorithms. High-performance C-backed implementations can be found in add-on packages such as `VNGraphs.jl`.
+
+## Index
+
+```@index
+Pages = ["coloring.md"]
+```
+
+## Full docs
+
+```@autodocs
+Modules = [Graphs]
+Pages = [
+    "vngraphs_stubs.jl",
+]
+```

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -454,7 +454,9 @@ export
 
     # planarity
     is_planar,
-    planar_maximally_filtered_graph
+    planar_maximally_filtered_graph,
+    chromatic_number,
+    edge_chromatic_number
 """
     Graphs
 
@@ -575,6 +577,7 @@ include("independentset/degree_ind_set.jl")
 include("independentset/maximal_ind_set.jl")
 include("vertexcover/degree_vertex_cover.jl")
 include("vertexcover/random_vertex_cover.jl")
+include("vngraphs_stubs.jl")
 include("Experimental/Experimental.jl")
 include("Parallel/Parallel.jl")
 include("Test/Test.jl")

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -480,6 +480,7 @@ and tutorials are available at the
 """
 Graphs
 include("interface.jl")
+include("vngraphs_stubs.jl")
 include("utils.jl")
 include("frozenvector.jl")
 include("deprecations.jl")
@@ -577,7 +578,6 @@ include("independentset/degree_ind_set.jl")
 include("independentset/maximal_ind_set.jl")
 include("vertexcover/degree_vertex_cover.jl")
 include("vertexcover/random_vertex_cover.jl")
-include("vngraphs_stubs.jl")
 include("Experimental/Experimental.jl")
 include("Parallel/Parallel.jl")
 include("Test/Test.jl")

--- a/src/vngraphs_stubs.jl
+++ b/src/vngraphs_stubs.jl
@@ -14,8 +14,10 @@ chromatic_number(g)
 ```
 """
 function chromatic_number(g::AbstractGraph, args...; kwargs...)
-    error("chromatic_number is not implemented in Graphs.jl. " *
-          "Please load VNGraphs.jl to use the very_nauty implementation.")
+    error(
+        "chromatic_number is not implemented in Graphs.jl. " *
+        "Please load VNGraphs.jl to use the very_nauty implementation.",
+    )
 end
 
 """
@@ -32,8 +34,10 @@ edge_chromatic_number(g)
 ```
 """
 function edge_chromatic_number(g::AbstractGraph, args...; kwargs...)
-    error("edge_chromatic_number is not implemented in Graphs.jl. " *
-          "Please load VNGraphs.jl to use the very_nauty implementation.")
+    error(
+        "edge_chromatic_number is not implemented in Graphs.jl. " *
+        "Please load VNGraphs.jl to use the very_nauty implementation.",
+    )
 end
 
 export chromatic_number, edge_chromatic_number

--- a/src/vngraphs_stubs.jl
+++ b/src/vngraphs_stubs.jl
@@ -40,4 +40,3 @@ function edge_chromatic_number(g::AbstractGraph, args...; kwargs...)
     )
 end
 
-export chromatic_number, edge_chromatic_number

--- a/src/vngraphs_stubs.jl
+++ b/src/vngraphs_stubs.jl
@@ -1,0 +1,39 @@
+# Algorithm stubs for VNGraphs.jl integration
+
+"""
+    chromatic_number(g, timeout=0)
+
+Return the chromatic number of the graph `g`.
+Note: This is a stub provided by `Graphs.jl`. For a concrete implementation,
+please use the `VNGraphs.jl` package which provides a fast C implementation
+via `very_nauty`.
+
+```julia
+using VNGraphs
+chromatic_number(g)
+```
+"""
+function chromatic_number(g::AbstractGraph, args...; kwargs...)
+    error("chromatic_number is not implemented in Graphs.jl. " *
+          "Please load VNGraphs.jl to use the very_nauty implementation.")
+end
+
+"""
+    edge_chromatic_number(g, timeout=0)
+
+Return the edge chromatic number of the graph `g`.
+Note: This is a stub provided by `Graphs.jl`. For a concrete implementation,
+please use the `VNGraphs.jl` package which provides a fast C implementation
+via `very_nauty`.
+
+```julia
+using VNGraphs
+edge_chromatic_number(g)
+```
+"""
+function edge_chromatic_number(g::AbstractGraph, args...; kwargs...)
+    error("edge_chromatic_number is not implemented in Graphs.jl. " *
+          "Please load VNGraphs.jl to use the very_nauty implementation.")
+end
+
+export chromatic_number, edge_chromatic_number

--- a/src/vngraphs_stubs.jl
+++ b/src/vngraphs_stubs.jl
@@ -39,4 +39,3 @@ function edge_chromatic_number(g::AbstractGraph, args...; kwargs...)
         "Please load VNGraphs.jl to use the very_nauty implementation.",
     )
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,6 +155,7 @@ tests = [
     "trees/prufer",
     "experimental/experimental",
     "planarity",
+    "vngraphs_stubs",
 ]
 
 @testset verbose = true "Graphs" begin

--- a/test/vngraphs_stubs.jl
+++ b/test/vngraphs_stubs.jl
@@ -3,17 +3,17 @@ using Test
 
 @testset "VNGraphs Stubs" begin
     g = path_graph(5)
-    
+
     @test_throws ErrorException chromatic_number(g)
     @test_throws ErrorException edge_chromatic_number(g)
-    
+
     # Verify the error message contains the suggestion to load VNGraphs.jl
     try
         chromatic_number(g)
     catch e
         @test contains(e.msg, "VNGraphs.jl")
     end
-    
+
     try
         edge_chromatic_number(g)
     catch e

--- a/test/vngraphs_stubs.jl
+++ b/test/vngraphs_stubs.jl
@@ -1,0 +1,22 @@
+using Graphs
+using Test
+
+@testset "VNGraphs Stubs" begin
+    g = path_graph(5)
+    
+    @test_throws ErrorException chromatic_number(g)
+    @test_throws ErrorException edge_chromatic_number(g)
+    
+    # Verify the error message contains the suggestion to load VNGraphs.jl
+    try
+        chromatic_number(g)
+    catch e
+        @test contains(e.msg, "VNGraphs.jl")
+    end
+    
+    try
+        edge_chromatic_number(g)
+    catch e
+        @test contains(e.msg, "VNGraphs.jl")
+    end
+end


### PR DESCRIPTION
Declares chromatic_number and edge_chromatic_number in Graphs.jl with helpful error hints directing users to install VNGraphs.jl for the fast C-backed very_nauty implementations.

Includes unit tests asserting the stubs throw the expected errors.
VNGraph pr : https://github.com/JuliaGraphs/VNGraphs.jl/pull/26

closes #448 
