### PR TITLE
Secure AirspeedVelocity PR benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,16 +1,15 @@
 name: Benchmarks
+
 on:
-  pull_request_target:
+  pull_request:
     branches: [master, main]
+
 permissions:
-  pull-requests: write
+  contents: read
 
 concurrency:
-  # group by workflow and ref; the last slightly strange component ensures that for pull
-  # requests, we limit to 1 concurrent job, but for the master branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main') || github.run_number }}
-  # Cancel intermediate builds, but only if it is a pull request build.
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   benchmark:
@@ -20,3 +19,4 @@ jobs:
         with:
           julia-version: '1'
           tune: 'false'
+          job-summary: 'true'


### PR DESCRIPTION
## Summary
- run the AirspeedVelocity benchmark workflow on `pull_request` instead of `pull_request_target`
- keep the workflow token read-only with `contents: read`
- write benchmark results to the job summary via `job-summary: true` instead of posting PR comments
- keep the branch filter as `[master, main]` so this file can be reused across repos

This avoids the classic `pull_request_target` pwn request problem: the old workflow could execute PR-controlled benchmark/package code while holding base-repository privileges.

cc @Krastanov