### PR TITLE
Fix `hash`-`isequal` contract for `SimpleEdgeIter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 We follow SemVer as most of the Julia ecosystem. Below you might see the "breaking" label even for minor version bumps -- we use it a bit more loosely to denote things that are not breaking by SemVer's definition but might cause breakage to people using internal or experimental APIs or undocumented implementation details. 
 
 ## unreleased
+- **(breaking)** `SimpleEdgeIter` now defines `hash` and `isequal`, so equal edge iterators are the same key of a `Dict` or `Set`. `isequal` is structural and only ever holds between two `SimpleEdgeIter`s, whereas `==` still compares a `SimpleEdgeIter` against an `AbstractVector{SimpleEdge}` or a `Set{SimpleEdge}`
 - `is_articulation(g, v)` for checking whether a single vertex is an articulation point
 - The iFUB algorithm is used for faster diameter calculation and now supports weighted graph diameter calculation
 - ECG community detection algorithm

--- a/src/SimpleGraphs/simpleedgeiter.jl
+++ b/src/SimpleGraphs/simpleedgeiter.jl
@@ -116,6 +116,31 @@ function ==(e1::SimpleEdgeIter, e2::SimpleEdgeIter)
     return true
 end
 
+Base.isequal(e1::SimpleEdgeIter, e2::SimpleEdgeIter) = e1 == e2
+# set `isequal`s to false to ensure the hash-isequal contract is fulfilled
+Base.isequal(::SimpleEdgeIter, ::AbstractVector{SimpleEdge}) = false
+Base.isequal(::AbstractVector{SimpleEdge}, ::SimpleEdgeIter) = false
+Base.isequal(::SimpleEdgeIter, ::Set{SimpleEdge}) = false
+Base.isequal(::Set{SimpleEdge}, ::SimpleEdgeIter) = false
+
+function Base.hash(eit::SimpleEdgeIter, h::UInt)
+    lists = fadj(eit.g)
+    n = something(findlast(!isempty, lists), 0)
+    h = hash(ne(eit.g), h)
+    h = hash(n, h)
+    # Sample about log(n) adjacency lists, working backwards with Fibonacci skips
+    i = n
+    skip = prevskip = 1
+    while i >= 1
+        list = lists[i]
+        h = hash(length(list), h)
+        isempty(list) || (h = hash(first(list), hash(last(list), h)))
+        i -= skip
+        skip, prevskip = skip + prevskip, skip
+    end
+    return h
+end
+
 in(e, es::SimpleEdgeIter) = has_edge(es.g, e)
 
 show(io::IO, eit::SimpleEdgeIter) = write(io, "SimpleEdgeIter $(ne(eit.g))")

--- a/test/simplegraphs/simpleedgeiter.jl
+++ b/test/simplegraphs/simpleedgeiter.jl
@@ -92,4 +92,54 @@
         @test edges(dga) == edges(dgb)
         @test edges(dgb) == edges(dga)
     end
+
+    @testset "hash and isequal" begin
+        ghb = copy(ga)
+        add_vertex!(ghb)
+        dghb = copy(dga)
+        add_vertex!(dghb)
+
+        # `isequal` agrees with `==` between two iterators, including for graphs that differ
+        # only in trailing isolated vertices
+        @test isequal(edges(ga), edges(ghb))
+        @test hash(edges(ga)) == hash(edges(ghb))
+        @test isequal(edges(dga), edges(dghb))
+        @test hash(edges(dga)) == hash(edges(dghb))
+        @test !isequal(edges(ga), edges(dga))
+
+        # graphs of differing eltype compare and hash equal
+        @test isequal(edges(SimpleGraph{UInt8}(ga)), edges(ga))
+        @test hash(edges(SimpleGraph{UInt8}(ga))) == hash(edges(ga))
+        @test isequal(edges(SimpleDiGraph{Int16}(dga)), edges(dga))
+        @test hash(edges(SimpleDiGraph{Int16}(dga))) == hash(edges(dga))
+
+        # edgeless graphs are equal regardless of vertex count or directedness
+        @test isequal(edges(SimpleGraph(0)), edges(SimpleGraph(7)))
+        @test hash(edges(SimpleGraph(0))) == hash(edges(SimpleGraph(7)))
+        @test isequal(edges(SimpleGraph(4)), edges(SimpleDiGraph(9)))
+        @test hash(edges(SimpleGraph(4))) == hash(edges(SimpleDiGraph(9)))
+
+        # `isequal` is structural where `==` is not, so edge containers are distinct keys
+        ea = collect(Edge, edges(ga))
+        sa = Set{Edge}(ea)
+        @test edges(ga) == ea
+        @test !isequal(edges(ga), ea)
+        @test !isequal(ea, edges(ga))
+        @test edges(ga) == sa
+        @test !isequal(edges(ga), sa)
+        @test !isequal(sa, edges(ga))
+
+        # `Dict` and `Set` use `isequal`
+        d = Dict{Any,Int}(edges(ga) => 1)
+        @test d[edges(ghb)] == 1
+        @test !haskey(d, ea)
+        @test !haskey(d, sa)
+        @test length(Set{Any}([edges(ga), edges(ghb), ea, sa])) == 3
+        @test length(unique(Any[edges(ga), edges(ghb)])) == 1
+
+        # distinct edge sets hash apart
+        @test length(
+            Set(hash(edges(SimpleGraph(20, 40; rng=StableRNG(s)))) for s in 1:200)
+        ) == 200
+    end
 end


### PR DESCRIPTION
Hashing and equality checks on `SimpleEdgeIter` do not currently not play together, which introduces correctness bugs when creating `Dict`s or `Set`s of `SimpleEdgeIter`s; see #504.

The obstacle to simply defining `hash` is that `==` relates a `SimpleEdgeIter` to both an `AbstractVector{SimpleEdge}` and a `Set{SimpleEdge}` (and `isequal` falls back to `==`). This forces `hash(iter) == hash(vec)` and `hash(iter) == hash(set)` but `hash(vec) != hash(set)` in Base, so no definition of `hash` can satisfy the contract.

This PR resolves this by
- defining separate `isequal`s that all evaluate to `false` if the container types are different.  `==` is left unchanged. 
- Implementing a new `hash(::SimpleEdgeIter)` that samples about `log(nv)` adjacency lists with Fibonacci skips, similar to Base.hash on arrays, reading only `length`, `first`, and `last` from each list. We run the sampling in reverse order, since the equality check runs in forward order and can then often return early. Vertices without edges are skipped, matching the behavior of `==(::SimpleEdgeIter, ::SimpleEdgeIter)`.