### PR TITLE
Up-to-date version of PR #32 "Performance improvements and bugfix to Tarjan's algorithm"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We follow SemVer as most of the Julia ecosystem. Below you might see the "breaki
 - `is_articulation(g, v)` for checking whether a single vertex is an articulation point
 - The iFUB algorithm is used for faster diameter calculation and now supports weighted graph diameter calculation
 - ECG community detection algorithm
+- Improve performance of `strongly_connected_components`
 
 ## v1.14.0 - 2026-02-26
 - **(breaking)** `neighbors`, `inneighbors`, and `outneighbors` now return an immutable `FrozenVector` instead of `Vector`

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -342,98 +342,135 @@ julia> strongly_connected_components_tarjan(g)
 function strongly_connected_components_tarjan end
 
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function strongly_connected_components_tarjan(
-    g::AG::IsDirected
-) where {T<:Integer,AG<:AbstractGraph{T}}
-    zero_t = zero(T)
-    one_t = one(T)
-    nvg = nv(g)
-    count = one_t
+@traitfn function strongly_connected_components_tarjan(g::AG::IsDirected) where {T <: Integer, AG <: AbstractGraph{T}}
+    if iszero(nv(g)) return Vector{Vector{T}}() end
+    _strongly_connected_components_tarjan(g, infer_nb_iterstate_type(g))    
+end
 
-    index = zeros(T, nvg)         # first time in which vertex is discovered
-    stack = Vector{T}()           # stores vertices which have been discovered and not yet assigned to any component
-    onstack = zeros(Bool, nvg)    # false if a vertex is waiting in the stack to receive a component assignment
-    lowlink = zeros(T, nvg)       # lowest index vertex that it can reach through back edge (index array not vertex id number)
-    parents = zeros(T, nvg)       # parent of every vertex in dfs
+#  In recursive form, Tarjans algorithm has a recursive call inside a for loop.
+#  To save the loop state of each recursive step in a stack efficiently, 
+#  we need to infer the type of its state (which should almost always be an int).
+infer_nb_iterstate_type(g::AbstractSimpleGraph) = Int
+
+function infer_nb_iterstate_type(g::AbstractGraph{T}) where {T}
+     destructure_type(x) = Any
+     destructure_type(x::Type{Union{Nothing, Tuple{A,B}}}) where {A,B} = B
+     # If no specific dispatch is given, we peek at the first vertex and use Base.Iterator magic to try infering the type.
+     destructure_type(Base.Iterators.approx_iter_type(typeof(outneighbors(g, one(T)))))
+end
+
+
+# Vertex size threshold below which it isn't worth keeping the DFS iteration state.
+is_large_vertex(g, v) = length(outneighbors(g, v)) >= 1024
+is_unvisited(data::AbstractVector, v::Integer) = iszero(data[v])
+
+
+
+# The key idea behind any variation on Tarjan's algorithm is to use DFS and pop off found components.
+# Whenever we are forced to backtrack, we are in a bottom cycle of the remaining graph, 
+# which we accumulate in a stack while backtracking, until we reach a local root.
+# A local root is a vertex from which we cannot reach any node that was visited earlier by DFS.
+# As such, when we have backtracked to it, we may pop off the contents the stack as a strongly connected component.
+function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}) where {T <: Integer, AG <: AbstractGraph{T}, S}
+    nvg = nv(g)
+    one_count = one(T)
+    count = nvg  # (Counting downwards) Visitation order for the branch being explored. Backtracks when we pop an scc.
+    component_count = one_count  # Index of the current component being discovered.
+    # Invariant 1: component_count is always smaller than count.
+    # Invariant 2: if rindex[v] < component_count, then v is in components[rindex[v]].
+    # This trivially lets us tell if a vertex belongs to a previously discovered scc without any extra bits, 
+    # just inequalities that combine naturally with other checks.
+
+    is_component_root = Vector{Bool}(undef, nvg) # Fields are set when tracing and read when backtracking, so can be initialized undef.
+    rindex = zeros(T, nvg)
     components = Vector{Vector{T}}()    # maintains a list of scc (order is not guaranteed in API)
 
+    stack = Vector{T}()     # while backtracking, stores vertices which have been discovered and not yet assigned to any component
     dfs_stack = Vector{T}()
+    largev_iterstate_stack = Vector{Tuple{T, S}}()  # For large vertexes we push the iteration state into a stack so we may resume it.
+    # adding this last stack fixes the O(|E|^2) performance bug that could previously be seen in large star graphs.
+    # The Tuples come from Julia's iteration protocol, and the code is structured so that we never push a Nothing into thise last stack.
 
     @inbounds for s in vertices(g)
-        if index[s] == zero_t
-            index[s] = count
-            lowlink[s] = count
-            onstack[s] = true
-            parents[s] = s
-            push!(stack, s)
-            count = count + one_t
+        if is_unvisited(rindex, s)
+            rindex[s] = count
+            is_component_root[s] = true
+            count -= one_count
 
             # start dfs from 's'
             push!(dfs_stack, s)
-
-            while !isempty(dfs_stack)
-                v = dfs_stack[end] # end is the most recently added item
-                u = zero_t
-                @inbounds for v_neighbor in outneighbors(g, v)
-                    if index[v_neighbor] == zero_t
-                        # unvisited neighbor found
-                        u = v_neighbor
+            if is_large_vertex(g, s)
+                push!(largev_iterstate_stack, iterate(outneighbors(g, s)))
+            end 
+            
+            @inbounds while !isempty(dfs_stack)
+                v = dfs_stack[end] #end is the most recently added item
+                outn = outneighbors(g, v)
+                v_is_large = is_large_vertex(g, v)
+                next = v_is_large ? pop!(largev_iterstate_stack) : iterate(outn)
+                while next !== nothing
+                    (v_neighbor, state) = next
+                    if is_unvisited(rindex, v_neighbor)
                         break
-                        # GOTO A push u onto DFS stack and continue DFS
-                    elseif onstack[v_neighbor]
-                        # we have already seen n, but can update the lowlink of v
-                        # which has the effect of possibly keeping v on the stack until n is ready to pop.
-                        # update lowest index 'v' can reach through out neighbors
-                        lowlink[v] = min(lowlink[v], index[v_neighbor])
+                        #GOTO A: push v_neighbor onto DFS stack and continue DFS
+                        # Note: This is no longer quadratic for (very large) tournament graphs or star graphs, 
+                        # as we save the iteration state in largev_iterstate_stack for large vertices.
+                        # The loop is tight so not saving the state still benchmarks well unless the vertex orders are large enough to make quadratic growth kick in.
+                    elseif (rindex[v_neighbor] > rindex[v])
+                        rindex[v] = rindex[v_neighbor]
+                        is_component_root[v] = false
                     end
+                    next = iterate(outn, state)
                 end
-                if u == zero_t
+                if isnothing(next) # Natural loop end.
                     # All out neighbors already visited or no out neighbors
                     # we have fully explored the DFS tree from v.
                     # time to start popping.
                     popped = pop!(dfs_stack)
-                    lowlink[parents[popped]] = min(
-                        lowlink[parents[popped]], lowlink[popped]
-                    )
-
-                    if index[v] == lowlink[v]
-                        # found a cycle in a completed dfs tree.
-                        component = Vector{T}()
-
-                        while !isempty(stack) # break when popped == v
-                            # drain stack until we see v.
-                            # everything on the stack until we see v is in the SCC rooted at v.
-                            popped = pop!(stack)
-                            push!(component, popped)
-                            onstack[popped] = false
-                            # popped has been assigned a component, so we will never see it again.
-                            if popped == v
-                                # we have drained the stack of an entire component.
-                                break
-                            end
+                    if is_component_root[popped]  # Found an SCC rooted at popped which is a bottom cycle in remaining graph.
+                        component = T[popped]
+                        count += one_count   # We also backtrack the count to reset it to what it would be if the component were never in the graph.
+                        while !isempty(stack) && (rindex[popped] >= rindex[stack[end]])  # Keep popping its children from the backtracking stack.
+                            newpopped = pop!(stack)
+                            rindex[newpopped] = component_count # Bigger than the value of anything unexplored.
+                            push!(component, newpopped) # popped has been assigned a component, so we will never see it again.
+                            count += one_count
                         end
-
-                        reverse!(component)
-                        push!(components, component)
+                        rindex[popped] = component_count
+                        component_count += one_count
+                        push!(components, component)                    
+                    else  # Invariant: the DFS stack can never be empty in this second branch where popped is not a root.
+                        if (rindex[popped] > rindex[dfs_stack[end]])
+                            rindex[dfs_stack[end]] = rindex[popped]
+                            is_component_root[dfs_stack[end]] = false
+                        end
+                        # Because we only push to stack when backtracking, it gets filled up less than in Tarjan's original algorithm.
+                        push!(stack, popped)  # For DAG inputs, the stack variable never gets touched at all.
                     end
-
-                else # LABEL A
+                    
+                else #LABEL A
                     # add unvisited neighbor to dfs
-                    index[u] = count
-                    lowlink[u] = count
-                    onstack[u] = true
-                    parents[u] = v
-                    count = count + one_t
-
-                    push!(stack, u)
+                    (u, state) = next
                     push!(dfs_stack, u)
+                    if v_is_large
+                        push!(largev_iterstate_stack, next) # Because this is the else branch of isnothing(state), we can push this on the stack.
+                    end
+                    if is_large_vertex(g, u)
+                        push!(largev_iterstate_stack, iterate(outneighbors(g, u)))  # Because u is large, iterate cannot return nothing, so we can push this on stack.
+                    end
+                    is_component_root[u] = true
+                    rindex[u] = count
+                    count -= one_count
                     # next iteration of while loop will expand the DFS tree from u.
                 end
             end
         end
     end
 
-    return components
+    #Unlike in the original Tarjans, rindex are potentially also worth returning here. 
+    # For any v, v is in components[rindex[v]], s it acts as a lookup table for components.
+    # Scipy's graph library returns only that and lets the user sort by its values.
+    return components # ,rindex
 end
 
 """

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -389,7 +389,7 @@ function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}
     dfs_stack = Vector{T}()
     largev_iterstate_stack = Vector{Tuple{T, S}}()  # For large vertexes we push the iteration state into a stack so we may resume it.
     # adding this last stack fixes the O(|E|^2) performance bug that could previously be seen in large star graphs.
-    # The Tuples come from Julia's iteration protocol, and the code is structured so that we never push a Nothing into thise last stack.
+    # The Tuples come from Julia's iteration protocol, and the code is structured so that we never push a Nothing into this last stack.
 
     @inbounds for s in vertices(g)
         if is_unvisited(rindex, s)
@@ -411,8 +411,7 @@ function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}
                 while next !== nothing
                     (v_neighbor, state) = next
                     if is_unvisited(rindex, v_neighbor)
-                        break
-                        #GOTO A: push v_neighbor onto DFS stack and continue DFS
+                        break #GOTO A: push v_neighbor onto DFS stack and continue DFS.
                         # Note: This is no longer quadratic for (very large) tournament graphs or star graphs, 
                         # as we save the iteration state in largev_iterstate_stack for large vertices.
                         # The loop is tight so not saving the state still benchmarks well unless the vertex orders are large enough to make quadratic growth kick in.
@@ -422,7 +421,7 @@ function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}
                     end
                     next = iterate(outn, state)
                 end
-                if isnothing(next) # Natural loop end.
+                if isnothing(next) # While loop above ended naturally.
                     # All out neighbors already visited or no out neighbors
                     # we have fully explored the DFS tree from v.
                     # time to start popping.

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -342,9 +342,13 @@ julia> strongly_connected_components_tarjan(g)
 function strongly_connected_components_tarjan end
 
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function strongly_connected_components_tarjan(g::AG::IsDirected) where {T <: Integer, AG <: AbstractGraph{T}}
-    if iszero(nv(g)) return Vector{Vector{T}}() end
-    _strongly_connected_components_tarjan(g, infer_nb_iterstate_type(g))    
+@traitfn function strongly_connected_components_tarjan(
+    g::AG::IsDirected
+) where {T<:Integer,AG<:AbstractGraph{T}}
+    if iszero(nv(g))
+        return Vector{Vector{T}}()
+    end
+    return _strongly_connected_components_tarjan(g, infer_nb_iterstate_type(g))
 end
 
 #  In recursive form, Tarjans algorithm has a recursive call inside a for loop.
@@ -368,19 +372,18 @@ function infer_nb_iterstate_type(g::AbstractGraph{T}) where {T}
     )
 end
 
-
 # Vertex size threshold below which it isn't worth keeping the DFS iteration state.
 is_large_vertex(g, v) = length(outneighbors(g, v)) >= 1024
 is_unvisited(data::AbstractVector, v::Integer) = iszero(data[v])
-
-
 
 # The key idea behind any variation on Tarjan's algorithm is to use DFS and pop off found components.
 # Whenever we are forced to backtrack, we are in a bottom cycle of the remaining graph, 
 # which we accumulate in a stack while backtracking, until we reach a local root.
 # A local root is a vertex from which we cannot reach any node that was visited earlier by DFS.
 # As such, when we have backtracked to it, we may pop off the contents the stack as a strongly connected component.
-function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}) where {T <: Integer, AG <: AbstractGraph{T}, S}
+function _strongly_connected_components_tarjan(
+    g::AG, nb_iter_statetype::Type{S}
+) where {T<:Integer,AG<:AbstractGraph{T},S}
     nvg = nv(g)
     one_count = one(T)
     count = nvg  # (Counting downwards) Visitation order for the branch being explored. Backtracks when we pop an scc.
@@ -396,7 +399,7 @@ function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}
 
     stack = Vector{T}()     # while backtracking, stores vertices which have been discovered and not yet assigned to any component
     dfs_stack = Vector{T}()
-    largev_iterstate_stack = Vector{Tuple{T, S}}()  # For large vertexes we push the iteration state into a stack so we may resume it.
+    largev_iterstate_stack = Vector{Tuple{T,S}}()  # For large vertexes we push the iteration state into a stack so we may resume it.
     # adding this last stack fixes the O(|E|^2) performance bug that could previously be seen in large star graphs.
     # The Tuples come from Julia's iteration protocol, and the code is structured so that we never push a Nothing into this last stack.
 
@@ -410,8 +413,8 @@ function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}
             push!(dfs_stack, s)
             if is_large_vertex(g, s)
                 push!(largev_iterstate_stack, iterate(outneighbors(g, s)))
-            end 
-            
+            end
+
             @inbounds while !isempty(dfs_stack)
                 v = dfs_stack[end] #end is the most recently added item
                 outn = outneighbors(g, v)
@@ -421,9 +424,9 @@ function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}
                     (v_neighbor, state) = next
                     if is_unvisited(rindex, v_neighbor)
                         break #GOTO A: push v_neighbor onto DFS stack and continue DFS.
-                        # Note: This is no longer quadratic for (very large) tournament graphs or star graphs, 
-                        # as we save the iteration state in largev_iterstate_stack for large vertices.
-                        # The loop is tight so not saving the state still benchmarks well unless the vertex orders are large enough to make quadratic growth kick in.
+                    # Note: This is no longer quadratic for (very large) tournament graphs or star graphs, 
+                    # as we save the iteration state in largev_iterstate_stack for large vertices.
+                    # The loop is tight so not saving the state still benchmarks well unless the vertex orders are large enough to make quadratic growth kick in.
                     elseif (rindex[v_neighbor] > rindex[v])
                         rindex[v] = rindex[v_neighbor]
                         is_component_root[v] = false
@@ -446,7 +449,7 @@ function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}
                         end
                         rindex[popped] = component_count
                         component_count += one_count
-                        push!(components, component)                    
+                        push!(components, component)
                     else  # Invariant: the DFS stack can never be empty in this second branch where popped is not a root.
                         if (rindex[popped] > rindex[dfs_stack[end]])
                             rindex[dfs_stack[end]] = rindex[popped]
@@ -455,7 +458,7 @@ function _strongly_connected_components_tarjan(g::AG, nb_iter_statetype::Type{S}
                         # Because we only push to stack when backtracking, it gets filled up less than in Tarjan's original algorithm.
                         push!(stack, popped)  # For DAG inputs, the stack variable never gets touched at all.
                     end
-                    
+
                 else #LABEL A
                     # add unvisited neighbor to dfs
                     (u, state) = next

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -350,13 +350,22 @@ end
 #  In recursive form, Tarjans algorithm has a recursive call inside a for loop.
 #  To save the loop state of each recursive step in a stack efficiently, 
 #  we need to infer the type of its state (which should almost always be an int).
-infer_nb_iterstate_type(g::AbstractSimpleGraph) = Int
+destructure_type(x) = Any
+destructure_type(::Type{Tuple{A,B}}) where {A,B} = B
+
+infer_nb_iterstate_type(::AbstractSimpleGraph{T}) where {T} = T
 
 function infer_nb_iterstate_type(g::AbstractGraph{T}) where {T}
-     destructure_type(x) = Any
-     destructure_type(x::Type{Union{Nothing, Tuple{A,B}}}) where {A,B} = B
-     # If no specific dispatch is given, we peek at the first vertex and use Base.Iterator magic to try infering the type.
-     destructure_type(Base.Iterators.approx_iter_type(typeof(outneighbors(g, one(T)))))
+    # If no specific dispatch is given, we peek at the first vertex and use Base.Iterator magic to try infering the type.
+    # `approx_iter_type` returns `Union{Nothing,Tuple{element,state}}`; strip the `Nothing`
+    # arm with `typesplit` so the state type can be read off by dispatching on the `Tuple`.
+    # (Dispatching directly on the `Union` would leave a type parameter unbound; see Aqua's
+    # `unbound_args` check.)
+    return destructure_type(
+        Base.typesplit(
+            Base.Iterators.approx_iter_type(typeof(outneighbors(g, one(T)))), Nothing
+        ),
+    )
 end
 
 

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -228,6 +228,60 @@
         @test sort(scc_k[4]) == [7, 8, 9, 10, 11, 12]
     end
 
+    # Soundness: Tarjan's `strongly_connected_components` must agree with the
+    # independent Kosaraju implementation on the partition into components.
+    # Component order is not part of the API, so we compare as sets of sets.
+    scc_partition(sccs) = Set(Set.(sccs))
+    @testset "Tarjan vs Kosaraju agreement (randomized)" begin
+        rng = StableRNG(1234)
+        for n in (1, 2, 5, 10, 25, 50), _ in 1:40
+            g = SimpleDiGraph(n)
+            for _ in 1:rand(rng, 0:(2 * n))    # density from empty to fairly dense
+                u, v = rand(rng, 1:n), rand(rng, 1:n)
+                u != v && add_edge!(g, u, v)
+            end
+            scc = strongly_connected_components_tarjan(g)
+            scc_k = strongly_connected_components_kosaraju(g)
+            # every vertex is assigned to exactly one component
+            @test sort(reduce(vcat, scc; init=Int[])) == 1:n
+            # both algorithms find the same partition
+            @test scc_partition(scc) == scc_partition(scc_k)
+            # components are reported in reverse-topological order (sinks first)
+            comp_of = Dict(v => i for (i, c) in enumerate(scc) for v in c)
+            @test all(comp_of[src(e)] >= comp_of[dst(e)] for e in edges(g))
+        end
+    end
+
+    # Regression test for the O(|E|^2) star-graph performance bug: this
+    # exercises the large-vertex (>= 1024 out-neighbours) DFS-iteration-state
+    # code path that the fast Tarjan implementation special-cases.
+    @testset "Tarjan on large / star graphs" begin
+        n = 3000    # centre degree >= 1024 triggers the `is_large_vertex` branch
+
+        out_star = SimpleDiGraph(n)     # n singleton components
+        for v in 2:n
+            add_edge!(out_star, 1, v)
+        end
+        @test length(strongly_connected_components_tarjan(out_star)) == n
+        @test scc_partition(strongly_connected_components_tarjan(out_star)) ==
+            scc_partition(strongly_connected_components_kosaraju(out_star))
+
+        bi_star = SimpleDiGraph(n)      # single component of size n
+        for v in 2:n
+            add_edge!(bi_star, 1, v)
+            add_edge!(bi_star, v, 1)
+        end
+        scc = strongly_connected_components_tarjan(bi_star)
+        @test length(scc) == 1 && length(only(scc)) == n
+        @test scc_partition(scc) ==
+            scc_partition(strongly_connected_components_kosaraju(bi_star))
+
+        # the large-vertex path must also be correct for a narrow eltype
+        out_star16 = SimpleDiGraph{Int16}(out_star)
+        @test scc_partition(strongly_connected_components_tarjan(out_star16)) ==
+            scc_partition(strongly_connected_components_kosaraju(out_star16))
+    end
+
     # Test examples with self-loops from
     # Graph-Theoretic Analysis of Finite Markov Chains by J.P. Jarvis & D. R. Shier
 


### PR DESCRIPTION
This replaces #32.

I ran into long runtimes with `strongly_connected_components` myself and then saw that there was this unmerged PR. I brushed it up a little and added the stress tests that have been requested. The performance claims made in the PR still hold against today's master branch:

| Graph | nv / ne | master | this PR | speedup | memory (master → PR) |
|---|---|---:|---:|---:|---|
| out-star | 10⁴ / 10⁴ | 27.4 ms | 146 µs | **188×** | 1.28 → 0.94 MiB |
| out-star | 10⁵ / 10⁵ | 2.72 s | 1.75 ms | **1550×** | 11.9 → 8.8 MiB |
| bidirectional star | 10⁵ / 2·10⁵ | 2.79 s | 1.34 ms | **2090×** | 6.0 → 4.4 MiB |
| dense random (deg ≈ 790) | 2·10³ / 1.6·10⁶ | 1.87 ms | 1.54 ms | 1.2× | 175 → 148 KiB |
| tournament | 2·10³ / 2.0·10⁶ | 2.02 ms | 1.91 ms | 1.1× | 175 → 160 KiB |
| random (k ≈ 10) | 5·10⁴ / 5·10⁵ | 5.68 ms | 4.09 ms | 1.4× | 3.9 → 3.1 MiB |
| sparse (k ≈ 2) | 10⁵ / 2·10⁵ | 8.18 ms | 5.20 ms | 1.6× | 8.9 → 7.0 MiB |
| big cycle | 2·10⁵ / 2·10⁵ | 4.94 ms | 4.19 ms | 1.2× | 20.9 → 17.9 MiB |
| path (DAG) | 2·10⁵ / 2·10⁵ | 7.00 ms | 4.99 ms | 1.4× | 36.1 → 24.7 MiB |

The asymptotic quadratic→linear win on star / high-out-degree graphs is confirmed (three orders of magnitude at 10⁵ vertices), and the new implementation is faster with lower memory on every other case as well. The small-margin rows (1.1×–1.6×) carry run-to-run noise but were consistently ≥ `master`.