### PR TITLE
Declare algorithms that are implemented by external packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We follow SemVer as most of the Julia ecosystem. Below you might see the "breaki
 - The iFUB algorithm is used for faster diameter calculation and now supports weighted graph diameter calculation
 - ECG community detection algorithm
 - `cycle_basis` now throws an error when it is called on a directed graph
+- Support for algorithms that Graphs.jl declares but leaves to an implementation package: `Graphs.EXTERNAL_ALGORITHMS`, `Graphs.@declare_external`, and a `MethodError` hint naming the package to install. `max_weight_perfect_matching`, to be implemented by LEMONGraphs.jl, is declared this way
 
 ## v1.14.0 - 2026-02-26
 - **(breaking)** `neighbors`, `inneighbors`, and `outneighbors` now return an immutable `FrozenVector` instead of `Vector`

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -70,6 +70,7 @@ pages_files = [
         "algorithms/distance.md",
         "algorithms/dominatingset.md",
         "algorithms/editdist.md",
+        "algorithms/external.md",
         "algorithms/independentset.md",
         "algorithms/iterators.md",
         "algorithms/linalg.md",

--- a/docs/src/algorithms/external.md
+++ b/docs/src/algorithms/external.md
@@ -1,0 +1,91 @@
+# Externally implemented algorithms
+
+Some algorithms are part of the _Graphs.jl_ API without being part of the
+_Graphs.jl_ implementation. The function and its docstring live here, so that
+the name is discoverable and stable, while the methods come from an
+implementation package, usually because the algorithm is a wrapper around a
+library written in another language, or because it pulls in dependencies that
+_Graphs.jl_ does not want.
+
+Calling one of these functions without the implementation package loaded raises
+a `MethodError` carrying a hint that names the package to install:
+
+```julia-repl
+julia> using Graphs
+
+julia> max_weight_perfect_matching(complete_graph(4), [1, 1, 1, 1, 1, 1], nothing)
+ERROR: MethodError: no method matching max_weight_perfect_matching(::SimpleGraph{Int64}, ::Vector{Int64}, ::Nothing)
+The function `max_weight_perfect_matching` exists, but no method is defined for this combination of argument types.
+
+`max_weight_perfect_matching` is declared by Graphs.jl but implemented elsewhere: install and load LEMONGraphs.jl to get a method for it.
+```
+
+## Index
+
+```@index
+Pages = ["external.md"]
+```
+
+## Full docs
+
+```@docs
+max_weight_perfect_matching
+```
+
+## Adding another externally implemented algorithm
+
+The setup is deliberately small, so that exposing a further algorithm is a
+mechanical change. In `src/external_algorithms.jl`:
+
+1. Declare the function with a docstring and no methods. The docstring should
+   describe the arguments and the return value, and carry an
+   `!!! note "Implementation package required"` admonition naming the package
+   that provides the methods.
+
+   ```julia
+   """
+       min_mean_cycle(g, weights, alg)
+
+   Find the directed cycle of `g` minimising the mean weight of its arcs.
+
+   !!! note "Implementation package required"
+       Graphs.jl only declares this function; it has no methods of its own.
+   """
+   function min_mean_cycle end
+   ```
+
+2. Register the implementation packages, which is what makes the error hint
+   informative:
+
+   ```julia
+   @declare_external min_mean_cycle "LEMONGraphs.jl"
+   ```
+
+3. Export the name from `src/Graphs.jl`, under the
+   `# declared here, implemented by external packages` comment.
+
+4. Add it to the `@docs` block above. `makedocs` runs with `checkdocs=:public`,
+   so an exported docstring that is not included in the manual fails the docs
+   build.
+
+The implementation package then adds a method, dispatching on its own algorithm
+marker so that several backends can coexist:
+
+```julia
+# in LEMONGraphs.jl
+function Graphs.min_mean_cycle(g::AbstractGraph, weights, ::LEMONAlgorithm)
+    # ... convert `g` and call into LEMON ...
+end
+```
+
+See
+[Dispatching to algorithm implementations in external packages](@ref "Dispatching to algorithm implementations in external packages")
+for the wider convention around these algorithm markers.
+
+## Reference
+
+```@docs
+Graphs.EXTERNAL_ALGORITHMS
+Graphs.@declare_external
+Graphs.external_algorithm_hint
+```

--- a/docs/src/ecosystem/graphalgorithms.md
+++ b/docs/src/ecosystem/graphalgorithms.md
@@ -18,6 +18,7 @@ Several other packages implement additional graph algorithms:
 Several packages make established graph libraries written in other languages accessible from within Julia and the _Graphs.jl_ ecosystem:
 
 - [IGraphs.jl](https://github.com/JuliaGraphs/IGraphs.jl) is a thin Julia wrapper around the C graphs library [igraph](https://igraph.org).
+- [LEMONGraphs.jl](https://github.com/JuliaGraphs/LEMONGraphs.jl) wraps the C++ library [LEMON](https://lemon.cs.elte.hu), providing graph types that implement the _Graphs.jl_ interface along with LEMON backends for matching, shortest paths and minimum cost flow.
 - [NautyGraphs.jl](https://github.com/JuliaGraphs/NautyGraphs.jl) provides graph structures compatible with the graph isomorphism library [_nauty_](https://pallini.di.uniroma1.it), allowing for efficient isomorphism checking and canonization, as well as computing the properties of graph automorphism groups.
 
 ## Dispatching to algorithm implementations in external packages
@@ -37,6 +38,8 @@ true
 ```
 
 Here, dispatching via `NautyAlg()` implicitly converts `g` to a _nauty_-compatible format and uses _nauty_ for the isomorphism computation.
+
+The same convention applies to algorithms that _Graphs.jl_ does not implement at all. Those are declared here, as a function with a docstring and no methods, and the implementation package supplies the methods; see [Externally implemented algorithms](@ref). Calling one without the implementation package loaded reports which package to install.
 
 ### Functions extended by IGraphs.jl
 

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -456,7 +456,10 @@ export
 
     # planarity
     is_planar,
-    planar_maximally_filtered_graph
+    planar_maximally_filtered_graph,
+
+    # declared here, implemented by external packages
+    max_weight_perfect_matching
 """
     Graphs
 
@@ -480,6 +483,7 @@ and tutorials are available at the
 """
 Graphs
 include("interface.jl")
+include("external_algorithms.jl")
 include("utils.jl")
 include("frozenvector.jl")
 include("deprecations.jl")
@@ -585,4 +589,12 @@ include("planarity.jl")
 include("spanningtrees/planar_maximally_filtered_graph.jl")
 
 using .LinAlg
+
+function __init__()
+    Base.Experimental.register_error_hint(MethodError) do io, exc, _argtypes, _kwargs
+        external_algorithm_hint(io, exc)
+    end
+    return nothing
+end
+
 end # module

--- a/src/external_algorithms.jl
+++ b/src/external_algorithms.jl
@@ -1,0 +1,111 @@
+"""
+    Graphs.EXTERNAL_ALGORITHMS
+
+Registry mapping every function that _Graphs.jl_ declares but does not
+implement to the packages known to provide a method for it.
+
+The entries are used by [`Graphs.external_algorithm_hint`](@ref) to turn the
+`MethodError` of a missing implementation into a message that names the package
+to install. Register a new entry with [`Graphs.@declare_external`](@ref).
+"""
+const EXTERNAL_ALGORITHMS = IdDict{Any,Vector{String}}()
+
+"""
+    @declare_external function_name "Package.jl" ["OtherPackage.jl" ...]
+
+Record that `function_name` is implemented by the listed packages rather than by
+_Graphs.jl_ itself.
+
+The function must already be declared (`function function_name end`). Declaring
+it separately keeps the docstring next to the signature it documents.
+"""
+macro declare_external(f, packages...)
+    return quote
+        EXTERNAL_ALGORITHMS[$(esc(f))] = String[$(map(esc, packages)...)]
+    end
+end
+
+"""
+    Graphs.external_algorithm_hint(io, exc)
+
+Append an actionable note to the `MethodError` of a function that _Graphs.jl_
+declares but leaves to an implementation package.
+
+Registered as a `MethodError` hint in `Graphs.__init__`. The wording depends on
+whether the function has any method at all and on whether an implementation
+package is already loaded, so that nobody is told to install a package they
+have.
+"""
+function external_algorithm_hint(io::IO, exc::MethodError)
+    packages = get(EXTERNAL_ALGORITHMS, exc.f, nothing)
+    packages === nothing && return nothing
+    name = nameof(exc.f)
+    list = join(packages, ", ", " or ")
+    loaded = filter(_is_package_loaded, packages)
+    if !isempty(methods(exc.f))
+        print(
+            io,
+            "\n\n`$name` is implemented by $list, but no method matches these " *
+            "argument types. Check the documentation of the implementation " *
+            "package for the signatures it supports.",
+        )
+    elseif isempty(loaded)
+        print(
+            io,
+            "\n\n`$name` is declared by Graphs.jl but implemented elsewhere: " *
+            "install and load $list to get a method for it.",
+        )
+    else
+        print(
+            io,
+            "\n\n`$name` is declared by Graphs.jl and implemented by $list. " *
+            "$(join(loaded, ", ", " and ")) is loaded but defines no method for it, " *
+            "so this version may not cover `$name` yet.",
+        )
+    end
+    return nothing
+end
+
+# A package is considered loaded when a top-level module of that name is; the
+# registry spells packages the way users install them, with the `.jl` suffix.
+function _is_package_loaded(package::AbstractString)
+    name = Symbol(chopsuffix(package, ".jl"))
+    return any(m -> nameof(m) === name, values(Base.loaded_modules))
+end
+
+"""
+    max_weight_perfect_matching(g, weights, alg)
+
+Compute a perfect matching of the undirected graph `g` maximising the total
+weight of the matched edges, and return a `(weight, mates)` tuple in which
+`mates[v]` is the vertex matched with `v`.
+
+A perfect matching covers every vertex exactly once, so it exists only if `g`
+has an even number of vertices and enough edges; implementations are expected
+to throw if none exists.
+
+!!! note "Implementation package required"
+    Graphs.jl only declares this function; it has no methods of its own.
+    [LEMONGraphs.jl](https://github.com/JuliaGraphs/LEMONGraphs.jl) is the
+    intended implementation, wrapping LEMON's `MaxWeightedPerfectMatching`:
+
+    ```julia
+    using Graphs, LEMONGraphs
+
+    g = complete_graph(4)
+    weight, mates = max_weight_perfect_matching(g, [10, 1, 1, 1, 1, 10], LEMONAlgorithm())
+    ```
+
+    That method arrives in the LEMONGraphs.jl release that follows this
+    declaration; until then the algorithm lives there under its own name,
+    `LEMONGraphs.maxweightedperfectmatching`.
+
+    Calling it without an implementation package loaded raises a `MethodError`
+    carrying a hint that names the package to install.
+
+See also the discussion of
+[dispatching to external implementations](@ref "Dispatching to algorithm implementations in external packages").
+"""
+function max_weight_perfect_matching end
+
+@declare_external max_weight_perfect_matching "LEMONGraphs.jl"

--- a/test/external_algorithms.jl
+++ b/test/external_algorithms.jl
@@ -1,0 +1,74 @@
+@testset "External algorithms" begin
+    @testset "declaration" begin
+        # declared, but deliberately without methods: the implementation lives
+        # in a separate package
+        @test isempty(methods(max_weight_perfect_matching))
+        @test haskey(Graphs.EXTERNAL_ALGORITHMS, max_weight_perfect_matching)
+        @test Graphs.EXTERNAL_ALGORITHMS[max_weight_perfect_matching] == ["LEMONGraphs.jl"]
+
+        # every registered entry must be a function Graphs.jl actually declares
+        for f in keys(Graphs.EXTERNAL_ALGORITHMS)
+            @test f isa Function
+            @test !isempty(Graphs.EXTERNAL_ALGORITHMS[f])
+        end
+    end
+
+    @testset "error hint" begin
+        # `showerror` runs the registered hints
+        message = try
+            max_weight_perfect_matching(path_graph(4), [1, 1, 1], nothing)
+            ""
+        catch err
+            sprint(showerror, err)
+        end
+        @test occursin("max_weight_perfect_matching", message)
+        @test occursin("LEMONGraphs.jl", message)
+        @test occursin("implemented elsewhere", message)
+
+        # an unregistered function must not gain a hint
+        untouched = try
+            Graphs.nv(nothing)
+            ""
+        catch err
+            sprint(showerror, err)
+        end
+        @test !occursin("LEMONGraphs.jl", untouched)
+    end
+
+    @testset "hint wording" begin
+        # called directly with synthetic MethodErrors, so that the test does not
+        # have to define methods on a function it shares with the rest of the suite
+        hint(f) = sprint(io -> Graphs.external_algorithm_hint(io, MethodError(f, ())))
+
+        # nothing registered: no hint at all
+        @test isempty(hint(sin))
+
+        # registered, no implementation package loaded
+        @test occursin("implemented elsewhere", hint(max_weight_perfect_matching))
+
+        # registered and the package is loaded, but still no method: the user
+        # must not be told to install what they already have
+        try
+            Graphs.EXTERNAL_ALGORITHMS[max_weight_perfect_matching] = ["Test.jl"]
+            message = hint(max_weight_perfect_matching)
+            @test occursin("Test.jl is loaded but defines no method", message)
+            @test !occursin("install and load", message)
+        finally
+            Graphs.EXTERNAL_ALGORITHMS[max_weight_perfect_matching] = ["LEMONGraphs.jl"]
+        end
+
+        # a registered function that does have methods
+        try
+            Graphs.EXTERNAL_ALGORITHMS[sin] = ["Nowhere.jl"]
+            @test occursin("no method matches these argument types", hint(sin))
+        finally
+            delete!(Graphs.EXTERNAL_ALGORITHMS, sin)
+        end
+    end
+
+    @testset "package detection" begin
+        @test Graphs._is_package_loaded("Test.jl")
+        @test Graphs._is_package_loaded("Test")
+        @test !Graphs._is_package_loaded("NoSuchPackageReally.jl")
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,7 @@ tests = [
     "trees/prufer",
     "experimental/experimental",
     "planarity",
+    "external_algorithms",
 ]
 
 @testset verbose = true "Graphs" begin


### PR DESCRIPTION
Part of #447.

LEMON has algorithms that Graphs.jl does not implement at all. This adds a way to expose such a name here, as a function with a docstring and no methods, together with a `MethodError` hint naming the package to install, so the name stays discoverable and stable while the methods live elsewhere.

`max_weight_perfect_matching` is declared this way as the first example; the method for it lands in LEMONGraphs.jl once this is released.

`docs/src/algorithms/external.md` covers how to add another one.
