### PR TITLE
Fix prerelease CI when the pre selector resolves to stable Julia

### DIFF
--- a/.github/workflows/ci-pre.yml
+++ b/.github/workflows/ci-pre.yml
@@ -24,10 +24,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
+        id: julia
         with:
           version: pre
       - uses: julia-actions/cache@v3
       - run: sed -i '/JET/d' test/Project.toml
+        # The pre selector can resolve to a stable release, which runs the JET tests.
+        if: ${{ contains(steps.julia.outputs.julia-version, '-') }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
The `pre` Julia selector now resolves to stable Julia 1.13.0. This workflow removes JET from the test project, but `test/runtests.jl` loads JET on stable releases, so the job fails with `Package JET not found in current path`.

Remove JET only when setup-julia's resolved version has a prerelease suffix. This keeps dependency selection consistent with the existing test runner and preserves JET checks when `pre` selects a stable release.

Validation:

- Reproduced the missing-JET failure with Julia 1.13.0 and the old dependency-removal step.
- Checked the condition with Julia 1.13.0 (JET retained) and 1.13.0-rc4 (JET removed).
- Actionlint 1.7.12 and `git diff --check` pass; independent review found no issues.
- Full local `Pkg.test()` runs passed on Julia 1.10.12, 1.11.9, 1.12.7, and 1.13.0, including JET, Aqua, doctests, and all registered algorithm/parallel tests. Each run has only the same two pre-existing `@test_broken` cases.
- Julia 1.13 documentation build and all 1,036 existing parallel assertions with two worker processes passed locally.
- All PR CI test jobs passed, including the complete OS/version matrix, stable Julia 1.13 in the prerelease workflow, and minimum dependencies.
- The local Julia 1.10.12 minimum-dependency full suite also passed: 30,978 assertions and the same two existing broken tests, with ArnoldiMethod 0.4.0, DataStructures 0.19.0, Inflate 0.1.3, and SimpleTraits 0.9.1 retained in the test environment.

CI-only change; no changelog entry is needed. Please apply `Skip-Changelog`.
